### PR TITLE
Ensures public inputs are less than the scalar field size

### DIFF
--- a/templates/verifier_groth.sol
+++ b/templates/verifier_groth.sol
@@ -182,11 +182,13 @@ contract Verifier {
         <%vk_ic_pts%>
     }
     function verify(uint[] memory input, Proof memory proof) internal view returns (uint) {
+        uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
         VerifyingKey memory vk = verifyingKey();
         require(input.length + 1 == vk.IC.length,"verifier-bad-input");
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
         for (uint i = 0; i < input.length; i++)
+            require(input[i] < snark_scalar_field);
             vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
         vk_x = Pairing.addition(vk_x, vk.IC[0]);
         if (!Pairing.pairingProd4(

--- a/templates/verifier_kimleeoh.sol
+++ b/templates/verifier_kimleeoh.sol
@@ -173,11 +173,13 @@ contract Verifier {
         <%vk_ic_pts%>
     }
     function verify(uint[] input, Proof proof) view internal returns (uint) {
+        uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
         VerifyingKey memory vk = verifyingKey();
         require(input.length + 1 == vk.IC.length);
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
         for (uint i = 0; i < input.length; i++)
+            require(input[i] < snark_scalar_field);
             vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
         vk_x = Pairing.addition(vk_x, vk.IC[0]);
         if (!Pairing.pairingProd4(

--- a/templates/verifier_original.sol
+++ b/templates/verifier_original.sol
@@ -183,11 +183,13 @@ contract Verifier {
         <%vk_ic_pts%>
     }
     function verify(uint[] memory input, Proof memory proof) internal view returns (uint) {
+        uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
         VerifyingKey memory vk = verifyingKey();
         require(input.length + 1 == vk.IC.length,"verifier-bad-input");
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
         for (uint i = 0; i < input.length; i++)
+            require(input[i] < snark_scalar_field);
             vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
         vk_x = Pairing.addition(vk_x, vk.IC[0]);
         if (!Pairing.pairingProd2(proof.A, vk.A, Pairing.negate(proof.A_p), Pairing.P2())) return 1;


### PR DESCRIPTION
The issue was first seen here: https://github.com/kobigurk/semaphore/issues/16

Based on the fix here: https://github.com/HarryR/ethsnarks/pull/141/files#diff-16b9d31d5ce4453863d191dd65657417R85

