### PR TITLE
instanceof bigInt [ bug fix ]

### DIFF
--- a/src/stringifybigint.js
+++ b/src/stringifybigint.js
@@ -23,7 +23,7 @@ module.exports.stringifyBigInts = stringifyBigInts;
 module.exports.unstringifyBigInts = unstringifyBigInts;
 
 function stringifyBigInts(o) {
-    if ((typeof(o) == "bigint") || (o instanceof bigInt))  {
+    if ((typeof(o) == "bigint") || o.isZero !== undefined)  {
         return o.toString(10);
     } else if (Array.isArray(o)) {
         return o.map(stringifyBigInts);


### PR DESCRIPTION
This PR is a quick fix of `stringifyBigInts` function. 

In case a browser does not support BigInt natively, previous check `(o instanceof bigInt)` does not work cause [bigint.js](https://github.com/iden3/snarkjs/blob/master/src/bigint.js#L224) exports a `function` (not a `Class`) of `bigInt` then. So the `instanceof` will never return `true`.  

Anyway, `o` has some defined bigInt methods (such as `isZero`)

But I think it would be better to define `wBigInt` as a Class.

The issue related to [websnark](https://github.com/iden3/websnark/blob/a0680804a5a3ab1ec397566453da275a9e2db6ca/tools/stringifybigint.js#L26) too.
