### PR TITLE
add verifyProof overload that accepts a single array of snark proof params

### DIFF
--- a/templates/verifier_groth.sol
+++ b/templates/verifier_groth.sol
@@ -220,4 +220,11 @@ contract Verifier {
             return false;
         }
     }
+    function verifyProof(uint[8] memory proof, uint[<%vk_input_length%>] memory inputs) public view returns (bool r) {
+        return verifyProof(
+            [proof[0], proof[1]],
+            [[proof[2], proof[3]], [proof[4], proof[5]]],
+            [proof[6], proof[7]],
+            inputs);
+    }
 }

--- a/templates/verifier_kimleeoh.sol
+++ b/templates/verifier_kimleeoh.sol
@@ -211,4 +211,11 @@ contract Verifier {
             return false;
         }
     }
+    function verifyProof(uint[8] memory proof, uint[<%vk_input_length%>] memory inputs) public view returns (bool r) {
+        return verifyProof(
+            [proof[0], proof[1]],
+            [[proof[2], proof[3]], [proof[4], proof[5]]],
+            [proof[6], proof[7]],
+            inputs);
+    }
 }

--- a/templates/verifier_original.sol
+++ b/templates/verifier_original.sol
@@ -238,6 +238,18 @@ contract Verifier {
             return false;
         }
     }
+    function verifyProof(uint[18] memory proof, uint[<%vk_input_length%>] memory inputs) public view returns (bool r) {
+        return verifyProof(
+            [proof[0], proof[1]],
+            [proof[2], proof[3]],
+            [[proof[4], proof[5]], [proof[6], proof[7]]],
+            [proof[8], proof[9]],
+            [proof[10], proof[11]],
+            [proof[12], proof[13]],
+            [proof[14], proof[15]],
+            [proof[16], proof[17]],
+            inputs);
+    }
 }
 
 


### PR DESCRIPTION
Supplying a, b, c proof variables separately might make sense from math standpoint but is confusing for users that don't know how snarks work. So I've added an overload for verifier template that accepts uint[] proof and inputs array.