### PR TITLE
Add error location to non-matching constraint

### DIFF
--- a/src/calculateWitness.js
+++ b/src/calculateWitness.js
@@ -223,11 +223,11 @@ class RTCtx {
         return this.witness[sId];
     }
 
-    assert(a,b) {
+    assert(a, b, location = '') {
         const ba = bigInt(a);
         const bb = bigInt(b);
         if (!ba.equals(bb)) {
-            throw new Error("Constraint doesn't match: " + ba.toString() + " != " + bb.toString());
+            throw new Error("Constraint doesn't match: " + ba.toString() + " != " + bb.toString() + (location ? " (" + location + ")" : ""));
         }
     }
 }


### PR DESCRIPTION
Error location is very handy. Requires https://github.com/iden3/circom/pull/40 to be merged after this PR.
```bash
circom && snarkjs setup --protocol groth && snarkjs generateverifier && snarkjs calculatewitness && snarkjs proof && snarkjs verify && snarkjs info
```

>Error: Constraint doesn't match: 66988482986943799312951692319852916441223464438865622325288249495563041273 != 66988482986943797804311918746082161243771806775581332108251452349691723776 **(/Users/k06a/Projects/snark1/circuit.circom:26:5)**
    at RTCtx.assert (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:230:19)
    at Object.__f [as hello] (eval at Circuit (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/circuit.js:46:33), <anonymous>:4:9)
    at RTCtx.triggerComponent (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:126:41)
    at callComponents.map (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:167:51)
    at Array.map (<anonymous>)
    at RTCtx.setSignalFullName (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:166:24)
    at RTCtx.setSignal (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:104:14)
    at /Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:50:17
    at iterateSelector (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:31:20)
    at calculateWitness (/Users/k06a/Projects/snark1/node_modules/snarkjs/src/calculateWitness.js:48:9)
ERROR: Error: Constraint doesn't match: 66988482986943799312951692319852916441223464438865622325288249495563041273 != 66988482986943797804311918746082161243771806775581332108251452349691723776 (/Users/k06a/Projects/snark1/circuit.circom:26:5)