### PR TITLE
Security and gas improvements to the Groth16 verifier contract

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -464,26 +464,26 @@ function generateVerifier_groth(verificationKey) {
     let template = fs.readFileSync(path.join( __dirname,  "templates", "verifier_groth.sol"), "utf-8");
 
 
-    const vkalfa1_str = `${verificationKey.vk_alfa_1[0].toString()},`+
-                        `${verificationKey.vk_alfa_1[1].toString()}`;
+    const vkalfa1_str = `uint256(${verificationKey.vk_alfa_1[0].toString()}), `+
+                        `uint256(${verificationKey.vk_alfa_1[1].toString()})`;
     template = template.replace("<%vk_alfa1%>", vkalfa1_str);
 
-    const vkbeta2_str = `[${verificationKey.vk_beta_2[0][1].toString()},`+
-                         `${verificationKey.vk_beta_2[0][0].toString()}], `+
-                        `[${verificationKey.vk_beta_2[1][1].toString()},` +
-                         `${verificationKey.vk_beta_2[1][0].toString()}]`;
+    const vkbeta2_str = `[uint256(${verificationKey.vk_beta_2[0][1].toString()}), `+
+                         `uint256(${verificationKey.vk_beta_2[0][0].toString()})], `+
+                        `[uint256(${verificationKey.vk_beta_2[1][1].toString()}), ` +
+                         `uint256(${verificationKey.vk_beta_2[1][0].toString()})]`;
     template = template.replace("<%vk_beta2%>", vkbeta2_str);
 
-    const vkgamma2_str = `[${verificationKey.vk_gamma_2[0][1].toString()},`+
-                          `${verificationKey.vk_gamma_2[0][0].toString()}], `+
-                         `[${verificationKey.vk_gamma_2[1][1].toString()},` +
-                          `${verificationKey.vk_gamma_2[1][0].toString()}]`;
+    const vkgamma2_str = `[uint256(${verificationKey.vk_gamma_2[0][1].toString()}), `+
+                          `uint256(${verificationKey.vk_gamma_2[0][0].toString()})], `+
+                         `[uint256(${verificationKey.vk_gamma_2[1][1].toString()}), ` +
+                          `uint256(${verificationKey.vk_gamma_2[1][0].toString()})]`;
     template = template.replace("<%vk_gamma2%>", vkgamma2_str);
 
-    const vkdelta2_str = `[${verificationKey.vk_delta_2[0][1].toString()},`+
-                          `${verificationKey.vk_delta_2[0][0].toString()}], `+
-                         `[${verificationKey.vk_delta_2[1][1].toString()},` +
-                          `${verificationKey.vk_delta_2[1][0].toString()}]`;
+    const vkdelta2_str = `[uint256(${verificationKey.vk_delta_2[0][1].toString()}), `+
+                          `uint256(${verificationKey.vk_delta_2[0][0].toString()})], `+
+                         `[uint256(${verificationKey.vk_delta_2[1][1].toString()}), ` +
+                          `uint256(${verificationKey.vk_delta_2[1][0].toString()})]`;
     template = template.replace("<%vk_delta2%>", vkdelta2_str);
 
     // The points
@@ -493,8 +493,8 @@ function generateVerifier_groth(verificationKey) {
     let vi = "";
     for (let i=0; i<verificationKey.IC.length; i++) {
         if (vi != "") vi = vi + "        ";
-        vi = vi + `vk.IC[${i}] = Pairing.G1Point(${verificationKey.IC[i][0].toString()},`+
-                                                `${verificationKey.IC[i][1].toString()});\n`;
+        vi = vi + `vk.IC[${i}] = Pairing.G1Point(uint256(${verificationKey.IC[i][0].toString()}), `+
+                                                `uint256(${verificationKey.IC[i][1].toString()}));\n`;
     }
     template = template.replace("<%vk_ic_pts%>", vi);
 

--- a/cli.js
+++ b/cli.js
@@ -489,6 +489,9 @@ function generateVerifier_groth(verificationKey) {
     // The points
 
     template = template.replace("<%vk_input_length%>", (verificationKey.IC.length-1).toString());
+
+    // this replace() is repeated as it appears twice in the template
+    template = template.replace("<%vk_ic_length%>", (verificationKey.IC.length).toString());
     template = template.replace("<%vk_ic_length%>", verificationKey.IC.length.toString());
     let vi = "";
     for (let i=0; i<verificationKey.IC.length; i++) {

--- a/templates/verifier_groth.sol
+++ b/templates/verifier_groth.sol
@@ -1,31 +1,51 @@
-//
 // Copyright 2017 Christian Reitwiessner
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
 // 2019 OKIMS
-//      ported to solidity 0.5
-//      fixed linter warnings
-//      added requiere error messages
-//
+
 pragma solidity ^0.5.0;
+
 library Pairing {
+
+    uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
     struct G1Point {
-        uint X;
-        uint Y;
+        uint256 X;
+        uint256 Y;
     }
+
     // Encoding of field elements is: X[0] * z + X[1]
     struct G2Point {
-        uint[2] X;
-        uint[2] Y;
+        uint256[2] X;
+        uint256[2] Y;
     }
-    /// @return the generator of G1
+
+    /*
+     * @return The generator of G1
+     */
     function P1() internal pure returns (G1Point memory) {
         return G1Point(1, 2);
     }
-    /// @return the generator of G2
+
+    /*
+     * @return The generator of G2
+     */
     function P2() internal pure returns (G2Point memory) {
+
         // Original code point
         return G2Point(
             [11559732032986387107991004021392285783925812861821192530917403151452391805634,
@@ -34,44 +54,52 @@ library Pairing {
              8495653923123431417604973247489272438418190587263600148770280649306958101930]
         );
 
-/*
-        // Changed by Jordi point
-        return G2Point(
-            [10857046999023057135944570762232829481370756359578518086990519993285655852781,
-             11559732032986387107991004021392285783925812861821192530917403151452391805634],
-            [8495653923123431417604973247489272438418190587263600148770280649306958101930,
-             4082367875863433681332203403145435568316851327593401208105741076214120093531]
-        );
-*/
     }
-    /// @return the negation of p, i.e. p.addition(p.negate()) should be zero.
+
+    /*
+     * @return The negation of p, i.e. p.plus(p.negate()) should be zero. 
+     */
     function negate(G1Point memory p) internal pure returns (G1Point memory) {
+
         // The prime q in the base field F_q for G1
-        uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
         if (p.X == 0 && p.Y == 0)
             return G1Point(0, 0);
-        return G1Point(p.X, q - (p.Y % q));
+        return G1Point(p.X, PRIME_Q - (p.Y % PRIME_Q));
     }
-    /// @return the sum of two points of G1
-    function addition(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
-        uint[4] memory input;
+
+    /*
+     * @return The sum of two points of G1
+     */
+    function plus(
+        G1Point memory p1,
+        G1Point memory p2
+    ) internal view returns (G1Point memory r) {
+
+        uint256[4] memory input;
         input[0] = p1.X;
         input[1] = p1.Y;
         input[2] = p2.X;
         input[3] = p2.Y;
         bool success;
+
         // solium-disable-next-line security/no-inline-assembly
         assembly {
             success := staticcall(sub(gas, 2000), 6, input, 0xc0, r, 0x60)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
+
         require(success,"pairing-add-failed");
     }
-    /// @return the product of a point on G1 and a scalar, i.e.
-    /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
-    function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
-        uint[3] memory input;
+
+    /*
+     * @return The product of a point on G1 and a scalar, i.e.
+     *         p == p.scalar_mul(1) and p.plus(p) == p.scalar_mul(2) for all
+     *         points p.
+     */
+    function scalar_mul(G1Point memory p, uint256 s) internal view returns (G1Point memory r) {
+
+        uint256[3] memory input;
         input[0] = p.X;
         input[1] = p.Y;
         input[2] = s;
@@ -84,68 +112,57 @@ library Pairing {
         }
         require (success,"pairing-mul-failed");
     }
-    /// @return the result of computing the pairing check
-    /// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
-    /// For example pairing([P1(), P1().negate()], [P2(), P2()]) should
-    /// return true.
-    function pairing(G1Point[] memory p1, G2Point[] memory p2) internal view returns (bool) {
+
+    /* @return The result of computing the pairing check
+     *         e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
+     *         For example,
+     *         pairing([P1(), P1().negate()], [P2(), P2()]) should return true.
+     */
+    function pairing(
+        G1Point[] memory p1,
+        G2Point[] memory p2
+    ) internal view returns (bool) {
+
         require(p1.length == p2.length,"pairing-lengths-failed");
-        uint elements = p1.length;
-        uint inputSize = elements * 6;
-        uint[] memory input = new uint[](inputSize);
-        for (uint i = 0; i < elements; i++)
+        uint256 elements = p1.length;
+        uint256 inputSize = elements * 6;
+        uint256[] memory input = new uint256[](inputSize);
+        for (uint256 i = 0; i < elements; i++)
         {
-            input[i * 6 + 0] = p1[i].X;
-            input[i * 6 + 1] = p1[i].Y;
-            input[i * 6 + 2] = p2[i].X[0];
-            input[i * 6 + 3] = p2[i].X[1];
-            input[i * 6 + 4] = p2[i].Y[0];
-            input[i * 6 + 5] = p2[i].Y[1];
+            uint256 j = i * 6;
+            input[j + 0] = p1[i].X;
+            input[j + 1] = p1[i].Y;
+            input[j + 2] = p2[i].X[0];
+            input[j + 3] = p2[i].X[1];
+            input[j + 4] = p2[i].Y[0];
+            input[j + 5] = p2[i].Y[1];
         }
-        uint[1] memory out;
+
+        uint256[1] memory out;
         bool success;
+
         // solium-disable-next-line security/no-inline-assembly
         assembly {
             success := staticcall(sub(gas, 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
+
         require(success,"pairing-opcode-failed");
+
         return out[0] != 0;
     }
-    /// Convenience method for a pairing check for two pairs.
-    function pairingProd2(G1Point memory a1, G2Point memory a2, G1Point memory b1, G2Point memory b2) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](2);
-        G2Point[] memory p2 = new G2Point[](2);
-        p1[0] = a1;
-        p1[1] = b1;
-        p2[0] = a2;
-        p2[1] = b2;
-        return pairing(p1, p2);
-    }
-    /// Convenience method for a pairing check for three pairs.
-    function pairingProd3(
-            G1Point memory a1, G2Point memory a2,
-            G1Point memory b1, G2Point memory b2,
-            G1Point memory c1, G2Point memory c2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](3);
-        G2Point[] memory p2 = new G2Point[](3);
-        p1[0] = a1;
-        p1[1] = b1;
-        p1[2] = c1;
-        p2[0] = a2;
-        p2[1] = b2;
-        p2[2] = c2;
-        return pairing(p1, p2);
-    }
-    /// Convenience method for a pairing check for four pairs.
+
+    /*
+     * A convenience method for a pairing check for three pairs.
+     */
     function pairingProd4(
             G1Point memory a1, G2Point memory a2,
             G1Point memory b1, G2Point memory b2,
             G1Point memory c1, G2Point memory c2,
             G1Point memory d1, G2Point memory d2
     ) internal view returns (bool) {
+
         G1Point[] memory p1 = new G1Point[](4);
         G2Point[] memory p2 = new G2Point[](4);
         p1[0] = a1;
@@ -156,11 +173,17 @@ library Pairing {
         p2[1] = b2;
         p2[2] = c2;
         p2[3] = d2;
+
         return pairing(p1, p2);
     }
 }
+
 contract Verifier {
+
     using Pairing for *;
+
+    uint256 constant SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+
     struct VerifyingKey {
         Pairing.G1Point alfa1;
         Pairing.G2Point beta2;
@@ -168,11 +191,13 @@ contract Verifier {
         Pairing.G2Point delta2;
         Pairing.G1Point[] IC;
     }
+
     struct Proof {
         Pairing.G1Point A;
         Pairing.G2Point B;
         Pairing.G1Point C;
     }
+
     function verifyingKey() internal pure returns (VerifyingKey memory vk) {
         vk.alfa1 = Pairing.G1Point(<%vk_alfa1%>);
         vk.beta2 = Pairing.G2Point(<%vk_beta2%>);
@@ -181,43 +206,61 @@ contract Verifier {
         vk.IC = new Pairing.G1Point[](<%vk_ic_length%>);
         <%vk_ic_pts%>
     }
-    function verify(uint[] memory input, Proof memory proof) internal view returns (uint) {
-        uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
-        VerifyingKey memory vk = verifyingKey();
-        require(input.length + 1 == vk.IC.length,"verifier-bad-input");
-        // Compute the linear combination vk_x
-        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
-        for (uint i = 0; i < input.length; i++) {
-            require(input[i] < snark_scalar_field,"verifier-gte-snark-scalar-field");
-            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
-        }
-        vk_x = Pairing.addition(vk_x, vk.IC[0]);
-        if (!Pairing.pairingProd4(
-            Pairing.negate(proof.A), proof.B,
-            vk.alfa1, vk.beta2,
-            vk_x, vk.gamma2,
-            proof.C, vk.delta2
-        )) return 1;
-        return 0;
-    }
+    
+    /*
+     * @returns Whether the proof is valid given the hardcoded verifying key
+     *          above and the public inputs
+     */
     function verifyProof(
-            uint[2] memory a,
-            uint[2][2] memory b,
-            uint[2] memory c,
-            uint[<%vk_input_length%>] memory input
-        ) public view returns (bool r) {
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[4] memory input
+    ) public view returns (bool r) {
+
         Proof memory proof;
         proof.A = Pairing.G1Point(a[0], a[1]);
         proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
         proof.C = Pairing.G1Point(c[0], c[1]);
-        uint[] memory inputValues = new uint[](input.length);
-        for(uint i = 0; i < input.length; i++){
-            inputValues[i] = input[i];
+
+        VerifyingKey memory vk = verifyingKey();
+
+        // TODO: hardcode `input.length` as a compile-time constant
+        require(input.length + 1 == vk.IC.length, "verifier-invalid-input-length");
+
+        // Compute the linear combination vk_x
+        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
+
+        // Make sure that proof.A, B, and C are each less than the snark scalar field
+        require(proof.A.X < SNARK_SCALAR_FIELD, "verifier-aX-gte-snark-scalar-field");
+        require(proof.A.Y < SNARK_SCALAR_FIELD, "verifier-aY-gte-snark-scalar-field");
+
+        require(proof.B.X[0] < SNARK_SCALAR_FIELD, "verifier-cX0-gte-snark-scalar-field");
+        require(proof.B.Y[0] < SNARK_SCALAR_FIELD, "verifier-cY0-gte-snark-scalar-field");
+
+        require(proof.B.X[1] < SNARK_SCALAR_FIELD, "verifier-cX1-gte-snark-scalar-field");
+        require(proof.B.Y[1] < SNARK_SCALAR_FIELD, "verifier-cY1-gte-snark-scalar-field");
+
+        require(proof.C.X < SNARK_SCALAR_FIELD, "verifier-cX-gte-snark-scalar-field");
+        require(proof.C.Y < SNARK_SCALAR_FIELD, "verifier-cY-gte-snark-scalar-field");
+
+        // Make sure that every input is less than the snark scalar field
+        for (uint256 i = 0; i < input.length; i++) {
+            require(input[i] < SNARK_SCALAR_FIELD,"verifier-gte-snark-scalar-field");
+            vk_x = Pairing.plus(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
         }
-        if (verify(inputValues, proof) == 0) {
-            return true;
-        } else {
-            return false;
-        }
+
+        vk_x = Pairing.plus(vk_x, vk.IC[0]);
+
+        return Pairing.pairingProd4(
+            Pairing.negate(proof.A),
+            proof.B,
+            vk.alfa1,
+            vk.beta2,
+            vk_x,
+            vk.gamma2,
+            proof.C,
+            vk.delta2
+        );
     }
 }

--- a/templates/verifier_groth.sol
+++ b/templates/verifier_groth.sol
@@ -146,6 +146,7 @@ contract Verifier {
     using Pairing for *;
 
     uint256 constant SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
 
     struct VerifyingKey {
         Pairing.G1Point alfa1;
@@ -192,7 +193,7 @@ contract Verifier {
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
 
-        // Make sure that proof.A, B, and C are each less than the snark scalar field
+        // Make sure that proof.A, B, and C are each less than the prime q
         require(proof.A.X < PRIME_Q, "verifier-aX-gte-prime-q");
         require(proof.A.Y < PRIME_Q, "verifier-aY-gte-prime-q");
 


### PR DESCRIPTION
Semaphore recently commissioned a security audit which included the Groth16 `verifier.sol`. This PR implements the suggested fixes.

1. Prevent proof malleability by ensuring that all values in proof.A, proof.B, and proof.C are smaller than prime q.

2. Changed all uint to uint256 for clarity.

3. Standardised code comment styles

4. Made the snark scalar field and prime q constant variables.

5. Removed unused pairingProd2 and pairingProd3 functions.

6. Merged verify() and verifyProof() for clarity and lower gas use.

7. Renamed addition() to plus() which is a verb

8. A small optimisation in pairing() to calculate i * 6 only once

9. Made VerifyingKey.IC a fixed-size array (since its size is hardcoded anyway)

10. Renamed verifier-bad-input to verifier-invalid-input-length

11. Removed Pairing.P1() and Pairing.P2() as they are not used.

12. Clarified if/else statement in negate()

13. Fixed suboptimal array allocation in pairingProd4(), and also merged it with pairing().

14. Hardcoded the value to check vk.IC.length against in verifyProof().

There is also an issue I discovered independently:

1. In some cases, a value in the verification key could be lower than 248 bits, which will cause the Solidity compiler to emit an error (Invalid type for argument in function call. Invalid implicit conversion from uint248[2] memory to uint256[2] memory requested.)

The fix (to explicitly cast the values to uint256) is included in the patch.
