### PR TITLE
Fix the bug of corrupt binfile due to missing await

### DIFF
--- a/src/binfileutils.js
+++ b/src/binfileutils.js
@@ -63,7 +63,7 @@ export async function endWriteSection(fd) {
     const sectionSize = fd.pos - fd.writingSection.pSectionSize - 8;
     const oldPos = fd.pos;
     fd.pos = fd.writingSection.pSectionSize;
-    fd.writeULE64(sectionSize);
+    await fd.writeULE64(sectionSize);
     fd.pos = oldPos;
     delete fd.writingSection;
 }

--- a/src/powersoftau_utils.js
+++ b/src/powersoftau_utils.js
@@ -25,7 +25,7 @@ export async function writePTauHeader(fd, curve, power, ceremonyPower) {
 
     const oldPos = fd.pos;
 
-    fd.writeULE64(headerSize, pHeaderSize);
+    await fd.writeULE64(headerSize, pHeaderSize);
 
     fd.pos = oldPos;
 }
@@ -287,7 +287,7 @@ export async function writeContributions(fd, curve, contributions) {
 
     const oldPos = fd.pos;
 
-    fd.writeULE64(contributionsSize, pContributionsSize);
+    await fd.writeULE64(contributionsSize, pContributionsSize);
     fd.pos = oldPos;
 }
 


### PR DESCRIPTION
These simple commands failed on my MacOS

```
snarkjs powersoftau new bn128 12 pot12_0000.ptau -v
snarkjs powersoftau contribute pot12_0000.ptau pot12_0001.ptau --name="First contribution" -v

[ERROR] snarkJS: Error: pot12_0000.ptau: File has no  contributions
    at readContributions (/Users/zhangzhuo/repos/zk/newzkmm/node_modules/snarkjs/build/cli.cjs:1912:30)
    at contribute (/Users/zhangzhuo/repos/zk/newzkmm/node_modules/snarkjs/build/cli.cjs:3284:33)

```

I checked why this error happened. Then I find the output file pot12_0000.ptau is wrong in fact. 

```
 $ xxd pot12_0000.ptau|head
00000000: 7074 6175 0100 0000 0700 0000 0100 0000  ptau............
00000010: 2c00 0000 0000 0000 2000 0000 47fd 7cd8  ,....... ...G.|.
00000020: 168c 203c 8dca 7168 916a 8197 5d58 8181  .. <..qh.j..]X..
00000030: b645 50b8 29a0 31e1 724e 6430 0c00 0000  .EP.).1.rNd0....
00000040: 0c00 0000 0200 0000 【0000 0000 0000 0000】  ................
00000050: 9d0d 8fc5 8d43 5dd3 3d0b c7f5 28eb 780a  .....C].=...(.x.
```

Notice bytes in 【】, these bytes should be the length of this section. But it is 0 in the file.
After some debugging, I find this error is due to the missing await. The writing pos is reset too early before the real write happens. So I make this PR to fix the bug.