### PR TITLE
Install blake2b-wasm from npm instead of git clone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,8 +168,9 @@
       "dev": true
     },
     "blake2b-wasm": {
-      "version": "git+https://github.com/jbaylina/blake2b-wasm.git#0d5f024b212429c7f50a7f533aa3a2406b5b42b3",
-      "from": "git+https://github.com/jbaylina/blake2b-wasm.git",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.1.0.tgz",
+      "integrity": "sha512-8zKXt9nk4cUCBU2jaUcSYcPA+UESwWOmb9Gsi8J35BifVb+tjVmbDhZbvmVmZEk6xZN1y35RNW6VqOwb0mkqsg==",
       "requires": {
         "nanoassert": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/iden3/snarkjs.git"
   },
   "dependencies": {
-    "blake2b-wasm": "https://github.com/jbaylina/blake2b-wasm.git",
+    "blake2b-wasm": "^2.1.0",
     "circom_runtime": "0.1.4",
     "fastfile": "0.0.13",
     "ffjavascript": "0.2.10",


### PR DESCRIPTION
The current implementation fetches `blake2b-wasm` package from git which makes it difficult to run on devices with no git such as CI nodes. It will be much easier if it is installed from npm instead.