### PR TITLE
Fixes the zkey export verificationkey command to allow the user to specify the output path of the verification key

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -495,7 +495,7 @@ async function groth16Verify(params, options) {
 // zkey export vkey [circuit.zkey] [verification_key.json]",
 async function zkeyExportVKey(params, options) {
     const zkeyName = params[0] || "circuit.zkey";
-    const verificationKeyName = params[2] || "verification_key.json";
+    const verificationKeyName = params[1] || "verification_key.json";
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 


### PR DESCRIPTION
The index of the verification key filepath parameter should be 1, not 2.