### PR TITLE
fix: new import style from circom_runtime

### DIFF
--- a/src/wtns_calculate.js
+++ b/src/wtns_calculate.js
@@ -1,9 +1,7 @@
 import * as fastFile from "fastfile";
-import circomRuntime from "circom_runtime";
+import { WitnessCalculatorBuilder } from "circom_runtime";
 import * as wtnsUtils from "./wtns_utils.js";
 import * as binFileUtils from "@iden3/binfileutils";
-
-const { WitnessCalculatorBuilder } = circomRuntime;
 
 export default async function wtnsCalculate(input, wasmFileName, wtnsFileName, options) {
 

--- a/src/wtns_debug.js
+++ b/src/wtns_debug.js
@@ -1,10 +1,8 @@
 import * as fastFile from "fastfile";
-import circomRuntime from "circom_runtime";
+import { WitnessCalculatorBuilder } from "circom_runtime";
 import * as wtnsUtils from "./wtns_utils.js";
 import * as binFileUtils from "@iden3/binfileutils";
 import loadSyms from "./loadsyms.js";
-
-const { WitnessCalculatorBuilder } = circomRuntime;
 
 export default async function wtnsDebug(input, wasmFileName, wtnsFileName, symName, options, logger) {
 


### PR DESCRIPTION
Once https://github.com/iden3/circom_runtime/pull/8 is merged and released, these imports need to be updated.