### PR TITLE
fix: ensure browser field in package.json are used by rollup

### DIFF
--- a/config/rollup.iife.config.js
+++ b/config/rollup.iife.config.js
@@ -25,9 +25,13 @@ export default {
             readline: empty,
             worker_threads: empty,
         }),
-        nodeResolve(),
+        nodeResolve({
+            browser: true
+        }),
         commonJS(),
-        replace({ "process.browser": !!process.env.BROWSER }),
+        replace({
+            "process.browser": !!process.env.BROWSER
+        }),
         visualizer(),
     ]
 };

--- a/config/rollup.iife_min.config.js
+++ b/config/rollup.iife_min.config.js
@@ -24,9 +24,13 @@ export default {
             readline: empty,
             worker_threads: empty,
         }),
-        nodeResolve(),
+        nodeResolve({
+            browser: true
+        }),
         commonJS(),
-        replace({ "process.browser": !!process.env.BROWSER }),
+        replace({
+            "process.browser": !!process.env.BROWSER
+        }),
         terser()
     ]
 };


### PR DESCRIPTION
Once https://github.com/iden3/ffjavascript/pull/11 is merged and released, these changes will ensure the `browser` field is correctly used by Rollup for the browser bundles.