### PR TITLE
Added the wtns convert command

### DIFF
--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -6319,6 +6319,15 @@ async function groth16Verify(vk_verifier, publicSignals, proof, logger) {
     return true;
 }
 
+async function wtnsConvertJson(jsonFileName, wtnsFileName, prime) {
+    const w = JSON.parse(fs.readFileSync(jsonFileName));
+    const fdWtns = await createBinFile(wtnsFileName, "wtns", 2, 2);
+
+    const p = ffjavascript.Scalar.fromString(prime, 10);
+    await write(fdWtns, w, p);
+    await fdWtns.close();
+}
+
 async function wtnsDebug(input, wasmFileName, wtnsFileName, symName, options, logger) {
 
     const fdWasm = await readExisting$2(wasmFileName);
@@ -6506,6 +6515,14 @@ const commands = [
         options: "-get|g -set|s -trigger|t",
         alias: ["wd"],
         action: wtnsDebug$1
+    },
+    {
+        cmd: "wtns convert json [witness.json] [witness.wtns] [prime]",
+        description: "Convert a witness JSON file to .wtns format",
+        longDescription: "Convert a witness JSON file to .wtns format. \nOptions:\n-g or --g : Log signal gets\n-s or --s : Log signal sets\n-t or --trigger : Log triggers ",
+        options: "-verbose|v",
+        alias: ["wcj"],
+        action: wtnsConvertJson$1
     },
     {
         cmd: "wtns export json [witness.wtns] [witnes.json]",
@@ -6746,6 +6763,16 @@ async function wtnsDebug$1(params, options) {
     return 0;
 }
 
+// wtns convert json [witness.json] [witness.wtns]
+async function wtnsConvertJson$1(params, options) {
+    const jsonName = params[0] || "witness.json";
+    const wtnsName = params[1] || "witness.wtns";
+    const prime = params[2] || "21888242871839275222246405745257275088548364400416034343698204186575808495617";
+
+    if (options.verbose) Logger__default['default'].setLogLevel("DEBUG");
+
+    await wtnsConvertJson(jsonName, wtnsName, prime);
+}
 
 // wtns export json  [witness.wtns] [witness.json]
 // -get|g -set|s -trigger|t

--- a/build/main.cjs
+++ b/build/main.cjs
@@ -4257,6 +4257,15 @@ var r1cs = /*#__PURE__*/Object.freeze({
     exportJson: r1csExportJson
 });
 
+async function wtnsConvertJson(jsonFileName, wtnsFileName, prime) {
+    const w = JSON.parse(fs.readFileSync(jsonFileName));
+    const fdWtns = await createBinFile(wtnsFileName, "wtns", 2, 2);
+
+    const p = ffjavascript.Scalar.fromString(prime, 10);
+    await write(fdWtns, w, p);
+    await fdWtns.close();
+}
+
 async function loadSymbols(symFileName) {
     const sym = {
         labelIdx2Name: [ "one" ],
@@ -4346,6 +4355,7 @@ async function wtnsExportJson(wtnsFileName) {
 var wtns = /*#__PURE__*/Object.freeze({
     __proto__: null,
     calculate: wtnsCalculate,
+    convert: wtnsConvertJson,
     debug: wtnsDebug,
     exportJson: wtnsExportJson
 });

--- a/cli.js
+++ b/cli.js
@@ -159,6 +159,14 @@ const commands = [
         action: wtnsDebug
     },
     {
+        cmd: "wtns convert json [witness.json] [witness.wtns] [prime]",
+        description: "Convert a witness JSON file to .wtns format",
+        longDescription: "Convert a witness JSON file to .wtns format. \nOptions:\n-g or --g : Log signal gets\n-s or --s : Log signal sets\n-t or --trigger : Log triggers ",
+        options: "-verbose|v",
+        alias: ["wcj"],
+        action: wtnsConvertJson
+    },
+    {
         cmd: "wtns export json [witness.wtns] [witnes.json]",
         description: "Calculate the witness with debug info.",
         longDescription: "Calculate the witness with debug info. \nOptions:\n-g or --g : Log signal gets\n-s or --s : Log signal sets\n-t or --trigger : Log triggers ",
@@ -397,6 +405,16 @@ async function wtnsDebug(params, options) {
     return 0;
 }
 
+// wtns convert json [witness.json] [witness.wtns]
+async function wtnsConvertJson(params, options) {
+    const jsonName = params[0] || "witness.json";
+    const wtnsName = params[1] || "witness.wtns";
+    const prime = params[2] || "21888242871839275222246405745257275088548364400416034343698204186575808495617";
+
+    if (options.verbose) Logger.setLogLevel("DEBUG");
+
+    await wtns.convert(jsonName, wtnsName, prime);
+}
 
 // wtns export json  [witness.wtns] [witness.json]
 // -get|g -set|s -trigger|t

--- a/src/wtns.js
+++ b/src/wtns.js
@@ -1,3 +1,4 @@
 export {default as calculate} from "./wtns_calculate.js";
+export {default as convert} from "./wtns_convert.js";
 export {default as debug} from "./wtns_debug.js";
 export {default as exportJson} from "./wtns_export_json.js";

--- a/src/wtns_convert.js
+++ b/src/wtns_convert.js
@@ -1,0 +1,13 @@
+import * as fs from "fs";
+import * as wtnsUtils from "./wtns_utils.js";
+import * as binFileUtils from "@iden3/binfileutils";
+import { Scalar } from "ffjavascript";
+
+export default async function wtnsConvertJson(jsonFileName, wtnsFileName, prime) {
+    const w = JSON.parse(fs.readFileSync(jsonFileName));
+    const fdWtns = await binFileUtils.createBinFile(wtnsFileName, "wtns", 2, 2);
+
+    const p = Scalar.fromString(prime, 10);
+    await wtnsUtils.write(fdWtns, w, p);
+    await fdWtns.close();
+}


### PR DESCRIPTION
This new command allows users to convert a JSON witness file into a `.wtns` file.

This is useful for those who use the C++ witness generator, especially for large circuits for which the WASM witness generator doesn't work.

It's also useful because the `rapidsnark` tool requires a `.wtns` file for proof generation. Without this command, it'll be difficult for developers of large circuits to `rapidsnark`.