### PR TITLE
chore: update rollup patterns

### DIFF
--- a/config/rollup.cjs.config.js
+++ b/config/rollup.cjs.config.js
@@ -1,5 +1,7 @@
-import { nodeResolve } from "@rollup/plugin-node-resolve";
-import commonJS from "@rollup/plugin-commonjs";
+import fs from "fs";
+import { builtinModules as builtin } from "module";
+
+const pkg = JSON.parse(fs.readFileSync("./package.json"));
 
 export default {
     input: "main.js",
@@ -8,26 +10,7 @@ export default {
         format: "cjs",
     },
     external: [
-        "fs",
-        "os",
-        "worker_threads",
-        "readline",
-        "crypto",
-        "path",
-        "big-integer",
-        "wasmsnark",
-        "circom_runtime",
-        "blake2b-wasm",
-
-        "ffjavascript",
-        "keccak",
-        "yargs",
-        "logplease"
-    ],
-    plugins: [
-        nodeResolve({ preferBuiltins: true }),
-        commonJS({
-            preserveSymlinks: true
-        }),
+        ...Object.keys(pkg.dependencies),
+        ...builtin,
     ]
 };

--- a/config/rollup.cli.config.js
+++ b/config/rollup.cli.config.js
@@ -1,6 +1,7 @@
-import { nodeResolve } from "@rollup/plugin-node-resolve";
-import commonJS from "@rollup/plugin-commonjs";
-import json from '@rollup/plugin-json';
+import fs from "fs";
+import { builtinModules as builtin } from "module";
+
+const pkg = JSON.parse(fs.readFileSync("./package.json"));
 
 export default {
     input: "cli.js",
@@ -10,31 +11,7 @@ export default {
         banner: "#! /usr/bin/env node\n",
     },
     external: [
-        "fs",
-        "os",
-        "worker_threads",
-        "readline",
-        "crypto",
-        "path",
-        "big-integer",
-        "wasmsnark",
-        "circom_runtime",
-        "blake2b-wasm",
-
-        "ffjavascript",
-        "keccak",
-        "yargs",
-        "logplease",
-    ],
-    plugins: [
-        nodeResolve({
-            preferBuiltins: true,
-        }),
-        commonJS({
-            preserveSymlinks: true,
-            include: "node_modules/**",
-            exclude: "node_modules/big-integer/**"
-        }),
-        json()
+        ...Object.keys(pkg.dependencies),
+        ...builtin,
     ]
 };

--- a/config/rollup.iife.config.js
+++ b/config/rollup.iife.config.js
@@ -23,10 +23,11 @@ export default {
             os: empty,
             crypto: empty,
             readline: empty,
-            worker_threads: empty,
         }),
         nodeResolve({
-            browser: true
+            browser: true,
+            preferBuiltins: false,
+            exportConditions: ['browser', 'default', 'module', 'require']
         }),
         commonJS(),
         replace({

--- a/config/rollup.iife_min.config.js
+++ b/config/rollup.iife_min.config.js
@@ -1,36 +1,15 @@
-import { nodeResolve } from "@rollup/plugin-node-resolve";
-import commonJS from "@rollup/plugin-commonjs";
-import virtual from '@rollup/plugin-virtual';
-import replace from '@rollup/plugin-replace';
+import config from './rollup.iife.config';
 import { terser } from "rollup-plugin-terser";
 
-const empty = 'export default {}';
-
 export default {
-    input: "main.js",
+    ...config,
     output: {
+        ...config.output,
         file: "build/snarkjs.min.js",
-        format: "iife",
-        globals: {
-            os: "null"
-        },
-        name: "snarkjs"
+        sourcemap: false,
     },
     plugins: [
-        virtual({
-            fs: empty,
-            os: empty,
-            crypto: empty,
-            readline: empty,
-            worker_threads: empty,
-        }),
-        nodeResolve({
-            browser: true
-        }),
-        commonJS(),
-        replace({
-            "process.browser": !!process.env.BROWSER
-        }),
-        terser()
+        ...config.plugins,
+        terser(),
     ]
 };


### PR DESCRIPTION
Relies on https://github.com/iden3/ffjavascript/pull/12 and https://github.com/iden3/ffjavascript/pull/13

This pulls in some new rollup patterns applied to the other repositories. For the commonjs builds, it ensures that no node_module is bundled into the output, even when dependencies are added to the package.json

For the browser, it sets up some additional config that is used for the `web-worker` abstraction in the ffjavascript project.
Additionally, I made the minified build just depend on the iife config, so they don't need to be updated separately.