### PR TITLE
fix: inject global object into browser build (fixes #77)

### DIFF
--- a/config/rollup.iife.config.js
+++ b/config/rollup.iife.config.js
@@ -1,5 +1,6 @@
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonJS from "@rollup/plugin-commonjs";
+import inject from "@rollup/plugin-inject";
 import virtual from "@rollup/plugin-virtual";
 import replace from "@rollup/plugin-replace";
 import visualizer from "rollup-plugin-visualizer";
@@ -23,6 +24,8 @@ export default {
             os: empty,
             crypto: empty,
             readline: empty,
+            // Stub out a "global" module that we can inject later
+            global: empty,
         }),
         nodeResolve({
             browser: true,
@@ -32,6 +35,10 @@ export default {
         commonJS(),
         replace({
             "process.browser": !!process.env.BROWSER
+        }),
+        inject({
+            // Inject the "global" virtual module if we see any reference to `global` in the code
+            global: "global",
         }),
         visualizer(),
     ]

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-inject": "^4.0.2",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.1.0",
     "@rollup/plugin-replace": "^2.3.4",


### PR DESCRIPTION
This fixes the iife builds by injecting a empty object as the "global" reference so the underlying modules don't error when trying to access.

It seems like this problem was introduced when all the underlying modules were converted to ESM because the iife build was relying on rollup's `commonjs` plugin to replace the `global` reference with an empty object. Now that the plugin doesn't run for those modules, it isn't replaced.

Fixes #77 