### PR TITLE
Switch to upstream blake2b-wasm

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@iden3/binfileutils": "0.0.8",
-    "blake2b-wasm": "https://github.com/jbaylina/blake2b-wasm.git",
+    "blake2b-wasm": "^2.3.0",
     "circom_runtime": "0.1.13",
     "ejs": "^3.1.6",
     "fastfile": "0.0.19",


### PR DESCRIPTION
I was able to get the required APIs added into blake2b-wasm so SnarkJS can switch back to the upstream library. See https://github.com/mafintosh/blake2b-wasm/pull/16

Closes #96
Closes #61