### PR TITLE
Update PlonkVerifier Solidity template

### DIFF
--- a/templates/verifier_plonk.sol.ejs
+++ b/templates/verifier_plonk.sol.ejs
@@ -23,7 +23,7 @@ pragma solidity >=0.7.0 <0.9.0;
 
 contract PlonkVerifier {
     
-    uint16 constant n =   <%=2**power%>;
+    uint32 constant n =   <%=2**power%>;
     uint16 constant nPublic =  <%=nPublic%>;
     uint16 constant nLagrange = <%=Math.max(nPublic, 1)%>;
     


### PR DESCRIPTION
For circuits with many constraints, n can exceed 2^16. Bumping it to uint32 allows for Plonk circuits with more constraints.