### PR TITLE
fix: uint size for higher powers in PLONK verifier sol

### DIFF
--- a/templates/verifier_plonk.sol.ejs
+++ b/templates/verifier_plonk.sol.ejs
@@ -23,7 +23,7 @@ pragma solidity >=0.7.0 <0.9.0;
 
 contract PlonkVerifier {
     
-    uint16 constant n =   <%=2**power%>;
+    uint<%=2**Math.ceil(Math.log2(power))%> constant n =   <%=2**power%>;
     uint16 constant nPublic =  <%=nPublic%>;
     uint16 constant nLagrange = <%=Math.max(nPublic, 1)%>;
     


### PR DESCRIPTION
The `sol` file generated using `solidityverifier` uses datatype `uint16` for variable `n`. This does not work for large number of maxConstraints, specifically when `power > 16`. The PR aims at adjusting the `uint` size based on `power`. 

A similar PR is is present at [https://github.com/iden3/snarkjs/pull/101](https://github.com/iden3/snarkjs/pull/101). However, it uses `uint32` even if the number of constraints is low enough. 