### PR TITLE
fix: Remove global shim from browser build

### DIFF
--- a/config/rollup.iife.config.js
+++ b/config/rollup.iife.config.js
@@ -32,6 +32,8 @@ export default {
         }),
         commonJS(),
         replace({
+            // The current default is false, but they are changing it next version
+            preventAssignment: false,
             "process.browser": !!process.env.BROWSER
         }),
         visualizer(),

--- a/config/rollup.iife.config.js
+++ b/config/rollup.iife.config.js
@@ -1,6 +1,5 @@
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonJS from "@rollup/plugin-commonjs";
-import inject from "@rollup/plugin-inject";
 import virtual from "@rollup/plugin-virtual";
 import replace from "@rollup/plugin-replace";
 import visualizer from "rollup-plugin-visualizer";
@@ -25,8 +24,6 @@ export default {
             crypto: empty,
             readline: empty,
             ejs: empty,
-            // Stub out a "global" module that we can inject later
-            global: empty,
         }),
         nodeResolve({
             browser: true,
@@ -36,10 +33,6 @@ export default {
         commonJS(),
         replace({
             "process.browser": !!process.env.BROWSER
-        }),
-        inject({
-            // Inject the "global" virtual module if we see any reference to `global` in the code
-            global: "global",
         }),
         visualizer(),
     ]

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",
-    "@rollup/plugin-inject": "^4.0.2",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.1.0",
     "@rollup/plugin-replace": "^2.3.4",


### PR DESCRIPTION
Once #118 is completed, we should be able to remove the global shim in the browser build because ffjavascript will be using `globalThis` instead of `global`.