### PR TITLE
feat: Improve proving speed by caching zkey curve

### DIFF
--- a/src/groth16_prove.js
+++ b/src/groth16_prove.js
@@ -46,7 +46,7 @@ export default async function groth16Prove(zkeyFileName, witnessFileName, logger
         throw new Error(`Invalid witness length. Circuit: ${zkey.nVars}, witness: ${wtns.nWitness}`);
     }
 
-    const curve = await getCurve(zkey.q);
+    const curve = zkey.curve;
     const Fr = curve.Fr;
     const G1 = curve.G1;
     const G2 = curve.G2;

--- a/src/plonk_prove.js
+++ b/src/plonk_prove.js
@@ -48,7 +48,7 @@ export default async function plonk16Prove(zkeyFileName, witnessFileName, logger
         throw new Error(`Invalid witness length. Circuit: ${zkey.nVars}, witness: ${wtns.nWitness}, ${zkey.nAdditions}`);
     }
 
-    const curve = await getCurve(zkey.q);
+    const curve = zkey.curve;
     const Fr = curve.Fr;
     const G1 = curve.G1;
     const n8r = curve.Fr.n8;

--- a/src/zkey_utils.js
+++ b/src/zkey_utils.js
@@ -237,19 +237,17 @@ async function readHeaderGroth16(fd, sections, toObject) {
     const n8r = await fd.readULE32();
     zkey.n8r = n8r;
     zkey.r = await binFileUtils.readBigInt(fd, n8r);
-
-    let curve = await getCurve(zkey.q);
-
+    zkey.curve = await getCurve(zkey.q);
     zkey.nVars = await fd.readULE32();
     zkey.nPublic = await fd.readULE32();
     zkey.domainSize = await fd.readULE32();
     zkey.power = log2(zkey.domainSize);
-    zkey.vk_alpha_1 = await readG1(fd, curve, toObject);
-    zkey.vk_beta_1 = await readG1(fd, curve, toObject);
-    zkey.vk_beta_2 = await readG2(fd, curve, toObject);
-    zkey.vk_gamma_2 = await readG2(fd, curve, toObject);
-    zkey.vk_delta_1 = await readG1(fd, curve, toObject);
-    zkey.vk_delta_2 = await readG2(fd, curve, toObject);
+    zkey.vk_alpha_1 = await readG1(fd, zkey.curve, toObject);
+    zkey.vk_beta_1 = await readG1(fd, zkey.curve, toObject);
+    zkey.vk_beta_2 = await readG2(fd, zkey.curve, toObject);
+    zkey.vk_gamma_2 = await readG2(fd, zkey.curve, toObject);
+    zkey.vk_delta_1 = await readG1(fd, zkey.curve, toObject);
+    zkey.vk_delta_2 = await readG2(fd, zkey.curve, toObject);
     await binFileUtils.endReadSection(fd);
 
     return zkey;
@@ -274,9 +272,7 @@ async function readHeaderPlonk(fd, sections, protocol, toObject) {
     const n8r = await fd.readULE32();
     zkey.n8r = n8r;
     zkey.r = await binFileUtils.readBigInt(fd, n8r);
-
-    let curve = await getCurve(zkey.q);
-
+    zkey.curve = await getCurve(zkey.q);
     zkey.nVars = await fd.readULE32();
     zkey.nPublic = await fd.readULE32();
     zkey.domainSize = await fd.readULE32();
@@ -286,15 +282,15 @@ async function readHeaderPlonk(fd, sections, protocol, toObject) {
     zkey.k1 = await fd.read(n8r);
     zkey.k2 = await fd.read(n8r);
 
-    zkey.Qm = await readG1(fd, curve, toObject);
-    zkey.Ql = await readG1(fd, curve, toObject);
-    zkey.Qr = await readG1(fd, curve, toObject);
-    zkey.Qo = await readG1(fd, curve, toObject);
-    zkey.Qc = await readG1(fd, curve, toObject);
-    zkey.S1 = await readG1(fd, curve, toObject);
-    zkey.S2 = await readG1(fd, curve, toObject);
-    zkey.S3 = await readG1(fd, curve, toObject);
-    zkey.X_2 = await readG2(fd, curve, toObject);
+    zkey.Qm = await readG1(fd, zkey.curve, toObject);
+    zkey.Ql = await readG1(fd, zkey.curve, toObject);
+    zkey.Qr = await readG1(fd, zkey.curve, toObject);
+    zkey.Qo = await readG1(fd, zkey.curve, toObject);
+    zkey.Qc = await readG1(fd, zkey.curve, toObject);
+    zkey.S1 = await readG1(fd, zkey.curve, toObject);
+    zkey.S2 = await readG1(fd, zkey.curve, toObject);
+    zkey.S3 = await readG1(fd, zkey.curve, toObject);
+    zkey.X_2 = await readG2(fd, zkey.curve, toObject);
 
     await binFileUtils.endReadSection(fd);
 


### PR DESCRIPTION
Speeds up proving by caching zkey getCurve call when reading headers and avoiding double calls in grothProve. On a smallish circuit (https://github.com/nalinbhardwaj/snarky-sudoku) this amounts to a ~30% reduction, which is pretty significant IMO:

**Before:**
![image](https://user-images.githubusercontent.com/6984346/150722897-63c360c0-5f30-4316-be6d-6ef56d02d939.png)
*~4 seconds runtime*

**After:**
<img width="755" alt="Screenshot 2022-01-23 at 8 35 10 PM" src="https://user-images.githubusercontent.com/6984346/150722944-700f2b6d-9afb-465e-afca-00d7a9d5a9e8.png">
*~3 seconds runtime*

Branched on #121 