### PR TITLE
fix: Add workaround for SES that reject arrow strings

### DIFF
--- a/src/wtns_debug.js
+++ b/src/wtns_debug.js
@@ -37,13 +37,15 @@ export default async function wtnsDebug(input, wasmFileName, wtnsFileName, symNa
     if (options.set) {
         if (!sym) sym = await loadSyms(symName);
         wcOps.logSetSignal= function(labelIdx, value) {
-            if (logger) logger.info("SET " + sym.labelIdx2Name[labelIdx] + " <-- " + value.toString());
+            // The line below splits the arrow log into 2 strings to avoid some Secure ECMAScript issues
+            if (logger) logger.info("SET " + sym.labelIdx2Name[labelIdx] + " <" + "-- " + value.toString());
         };
     }
     if (options.get) {
         if (!sym) sym = await loadSyms(symName);
         wcOps.logGetSignal= function(varIdx, value) {
-            if (logger) logger.info("GET " + sym.labelIdx2Name[varIdx] + " --> " + value.toString());
+            // The line below splits the arrow log into 2 strings to avoid some Secure ECMAScript issues
+            if (logger) logger.info("GET " + sym.labelIdx2Name[varIdx] + " --" + "> " + value.toString());
         };
     }
     if (options.trigger) {


### PR DESCRIPTION
This splits the `<--` and `-->` arrows into 2 separate strings to avoid a false-positive rejection from Secure ECMAScript.