### PR TITLE
Groth16 verifier.sol: Cleanup and always use revert errors

### DIFF
--- a/templates/verifier_groth16.sol.ejs
+++ b/templates/verifier_groth16.sol.ejs
@@ -1,3 +1,4 @@
+// This file is generated with [snarkJS](https://github.com/iden3/snarkjs).
 //
 // Copyright 2017 Christian Reitwiessner
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -9,173 +10,146 @@
 //      fixed linter warnings
 //      added requiere error messages
 //
-//
+// 2021 Remco Bloemen
+//       cleaned up code
+//       added InvalidProve() error
+//       always revert with InvalidProof() on invalid proof
+//       make Pairing strict
+//      
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.6.11;
-library Pairing {
-    struct G1Point {
-        uint X;
-        uint Y;
-    }
-    // Encoding of field elements is: X[0] * z + X[1]
-    struct G2Point {
-        uint[2] X;
-        uint[2] Y;
-    }
-    /// @return the generator of G1
-    function P1() internal pure returns (G1Point memory) {
-        return G1Point(1, 2);
-    }
-    /// @return the generator of G2
-    function P2() internal pure returns (G2Point memory) {
-        // Original code point
-        return G2Point(
-            [11559732032986387107991004021392285783925812861821192530917403151452391805634,
-             10857046999023057135944570762232829481370756359578518086990519993285655852781],
-            [4082367875863433681332203403145435568316851327593401208105741076214120093531,
-             8495653923123431417604973247489272438418190587263600148770280649306958101930]
-        );
+pragma solidity ^0.8.4;
 
-/*
-        // Changed by Jordi point
-        return G2Point(
-            [10857046999023057135944570762232829481370756359578518086990519993285655852781,
-             11559732032986387107991004021392285783925812861821192530917403151452391805634],
-            [8495653923123431417604973247489272438418190587263600148770280649306958101930,
-             4082367875863433681332203403145435568316851327593401208105741076214120093531]
-        );
-*/
+library Pairing {
+
+  error InvalidProof();
+
+  // The prime q in the base field F_q for G1
+  uint256 constant BASE_MODULUS = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
+  // The prime moludus of the scalar field of G1.
+  uint256 constant SCALAR_MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+
+  struct G1Point {
+    uint256 X;
+    uint256 Y;
+  }
+
+  // Encoding of field elements is: X[0] * z + X[1]
+  struct G2Point {
+    uint256[2] X;
+    uint256[2] Y;
+  }
+
+  /// @return the generator of G1
+  function P1() internal pure returns (G1Point memory) {
+    return G1Point(1, 2);
+  }
+
+  /// @return the generator of G2
+  function P2() internal pure returns (G2Point memory) {
+    return
+      G2Point(
+        [
+          11559732032986387107991004021392285783925812861821192530917403151452391805634,
+          10857046999023057135944570762232829481370756359578518086990519993285655852781
+        ],
+        [
+          4082367875863433681332203403145435568316851327593401208105741076214120093531,
+          8495653923123431417604973247489272438418190587263600148770280649306958101930
+        ]
+      );
+  }
+
+  /// @return r the negation of p, i.e. p.addition(p.negate()) should be zero.
+  function negate(G1Point memory p) internal pure returns (G1Point memory r) {
+    if (p.X == 0 && p.Y == 0) return G1Point(0, 0);
+    // Validate input or revert
+    if (p.X >= BASE_MODULUS || p.Y >= BASE_MODULUS) revert InvalidProof();
+    // We know p.Y > 0 and p.Y < BASE_MODULUS.
+    return G1Point(p.X, BASE_MODULUS - p.Y);
+  }
+
+  /// @return r the sum of two points of G1
+  function addition(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
+    // By EIP-196 all input is validated to be less than the BASE_MODULUS and form points
+    // on the curve.
+    uint256[4] memory input;
+    input[0] = p1.X;
+    input[1] = p1.Y;
+    input[2] = p2.X;
+    input[3] = p2.Y;
+    bool success;
+    // solium-disable-next-line security/no-inline-assembly
+    assembly {
+      success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
     }
-    /// @return r the negation of p, i.e. p.addition(p.negate()) should be zero.
-    function negate(G1Point memory p) internal pure returns (G1Point memory r) {
-        // The prime q in the base field F_q for G1
-        uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
-        if (p.X == 0 && p.Y == 0)
-            return G1Point(0, 0);
-        return G1Point(p.X, q - (p.Y % q));
+    if (!success) revert InvalidProof();
+  }
+
+  /// @return r the product of a point on G1 and a scalar, i.e.
+  /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
+  function scalar_mul(G1Point memory p, uint256 s) internal view returns (G1Point memory r) {
+    // By EIP-196 the values p.X and p.Y are verified to less than the BASE_MODULUS and 
+    // form a valid point on the curve. But the scalar is not verified, so we do that explicitelly.
+    if (s >= SCALAR_MODULUS) revert InvalidProof();
+    uint256[3] memory input;
+    input[0] = p.X;
+    input[1] = p.Y;
+    input[2] = s;
+    bool success;
+    // solium-disable-next-line security/no-inline-assembly
+    assembly {
+      success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
     }
-    /// @return r the sum of two points of G1
-    function addition(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
-        uint[4] memory input;
-        input[0] = p1.X;
-        input[1] = p1.Y;
-        input[2] = p2.X;
-        input[3] = p2.Y;
-        bool success;
-        // solium-disable-next-line security/no-inline-assembly
-        assembly {
-            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
-        }
-        require(success,"pairing-add-failed");
+    if (!success) revert InvalidProof();
+  }
+
+  /// Asserts the pairing check
+  /// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
+  /// For example pairing([P1(), P1().negate()], [P2(), P2()]) should succeed
+  function pairingCheck(G1Point[] memory p1, G2Point[] memory p2) internal view {
+    // By EIP-197 all input is verified to be less than the BASE_MODULUS and form elements in their
+    // respective groups of the right order.
+    if (p1.length != p2.length) revert InvalidProof();
+    uint256 elements = p1.length;
+    uint256 inputSize = elements * 6;
+    uint256[] memory input = new uint256[](inputSize);
+    for (uint256 i = 0; i < elements; i++) {
+      input[i * 6 + 0] = p1[i].X;
+      input[i * 6 + 1] = p1[i].Y;
+      input[i * 6 + 2] = p2[i].X[0];
+      input[i * 6 + 3] = p2[i].X[1];
+      input[i * 6 + 4] = p2[i].Y[0];
+      input[i * 6 + 5] = p2[i].Y[1];
     }
-    /// @return r the product of a point on G1 and a scalar, i.e.
-    /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
-    function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
-        uint[3] memory input;
-        input[0] = p.X;
-        input[1] = p.Y;
-        input[2] = s;
-        bool success;
-        // solium-disable-next-line security/no-inline-assembly
-        assembly {
-            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
-        }
-        require (success,"pairing-mul-failed");
+    uint256[1] memory out;
+    bool success;
+    // solium-disable-next-line security/no-inline-assembly
+    assembly {
+      success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
     }
-    /// @return the result of computing the pairing check
-    /// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
-    /// For example pairing([P1(), P1().negate()], [P2(), P2()]) should
-    /// return true.
-    function pairing(G1Point[] memory p1, G2Point[] memory p2) internal view returns (bool) {
-        require(p1.length == p2.length,"pairing-lengths-failed");
-        uint elements = p1.length;
-        uint inputSize = elements * 6;
-        uint[] memory input = new uint[](inputSize);
-        for (uint i = 0; i < elements; i++)
-        {
-            input[i * 6 + 0] = p1[i].X;
-            input[i * 6 + 1] = p1[i].Y;
-            input[i * 6 + 2] = p2[i].X[0];
-            input[i * 6 + 3] = p2[i].X[1];
-            input[i * 6 + 4] = p2[i].Y[0];
-            input[i * 6 + 5] = p2[i].Y[1];
-        }
-        uint[1] memory out;
-        bool success;
-        // solium-disable-next-line security/no-inline-assembly
-        assembly {
-            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
-        }
-        require(success,"pairing-opcode-failed");
-        return out[0] != 0;
-    }
-    /// Convenience method for a pairing check for two pairs.
-    function pairingProd2(G1Point memory a1, G2Point memory a2, G1Point memory b1, G2Point memory b2) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](2);
-        G2Point[] memory p2 = new G2Point[](2);
-        p1[0] = a1;
-        p1[1] = b1;
-        p2[0] = a2;
-        p2[1] = b2;
-        return pairing(p1, p2);
-    }
-    /// Convenience method for a pairing check for three pairs.
-    function pairingProd3(
-            G1Point memory a1, G2Point memory a2,
-            G1Point memory b1, G2Point memory b2,
-            G1Point memory c1, G2Point memory c2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](3);
-        G2Point[] memory p2 = new G2Point[](3);
-        p1[0] = a1;
-        p1[1] = b1;
-        p1[2] = c1;
-        p2[0] = a2;
-        p2[1] = b2;
-        p2[2] = c2;
-        return pairing(p1, p2);
-    }
-    /// Convenience method for a pairing check for four pairs.
-    function pairingProd4(
-            G1Point memory a1, G2Point memory a2,
-            G1Point memory b1, G2Point memory b2,
-            G1Point memory c1, G2Point memory c2,
-            G1Point memory d1, G2Point memory d2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](4);
-        G2Point[] memory p2 = new G2Point[](4);
-        p1[0] = a1;
-        p1[1] = b1;
-        p1[2] = c1;
-        p1[3] = d1;
-        p2[0] = a2;
-        p2[1] = b2;
-        p2[2] = c2;
-        p2[3] = d2;
-        return pairing(p1, p2);
-    }
+    if (!success || out[0] != 1) revert InvalidProof();
+  }
 }
+
 contract Verifier {
-    using Pairing for *;
-    struct VerifyingKey {
-        Pairing.G1Point alfa1;
-        Pairing.G2Point beta2;
-        Pairing.G2Point gamma2;
-        Pairing.G2Point delta2;
-        Pairing.G1Point[] IC;
-    }
-    struct Proof {
-        Pairing.G1Point A;
-        Pairing.G2Point B;
-        Pairing.G1Point C;
-    }
-    function verifyingKey() internal pure returns (VerifyingKey memory vk) {
+  using Pairing for *;
+
+  struct VerifyingKey {
+    Pairing.G1Point alfa1;
+    Pairing.G2Point beta2;
+    Pairing.G2Point gamma2;
+    Pairing.G2Point delta2;
+    Pairing.G1Point[] IC;
+  }
+
+  struct Proof {
+    Pairing.G1Point A;
+    Pairing.G2Point B;
+    Pairing.G1Point C;
+  }
+
+  function verifyingKey() internal pure returns (VerifyingKey memory vk) {
         vk.alfa1 = Pairing.G1Point(
             <%=vk_alpha_1[0]%>,
             <%=vk_alpha_1[1]%>
@@ -207,44 +181,36 @@ contract Verifier {
         );                                      
         <% } %>
     }
-    function verify(uint[] memory input, Proof memory proof) internal view returns (uint) {
-        uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
-        VerifyingKey memory vk = verifyingKey();
-        require(input.length + 1 == vk.IC.length,"verifier-bad-input");
-        // Compute the linear combination vk_x
-        Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
-        for (uint i = 0; i < input.length; i++) {
-            require(input[i] < snark_scalar_field,"verifier-gte-snark-scalar-field");
-            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
-        }
-        vk_x = Pairing.addition(vk_x, vk.IC[0]);
-        if (!Pairing.pairingProd4(
-            Pairing.negate(proof.A), proof.B,
-            vk.alfa1, vk.beta2,
-            vk_x, vk.gamma2,
-            proof.C, vk.delta2
-        )) return 1;
-        return 0;
-    }
-    /// @return r  bool true if proof is valid
-    function verifyProof(
-            uint[2] memory a,
-            uint[2][2] memory b,
-            uint[2] memory c,
-            uint[<%=IC.length-1%>] memory input
-        ) public view returns (bool r) {
-        Proof memory proof;
-        proof.A = Pairing.G1Point(a[0], a[1]);
-        proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
-        proof.C = Pairing.G1Point(c[0], c[1]);
-        uint[] memory inputValues = new uint[](input.length);
-        for(uint i = 0; i < input.length; i++){
-            inputValues[i] = input[i];
-        }
-        if (verify(inputValues, proof) == 0) {
-            return true;
-        } else {
-            return false;
-        }
-    }
+
+  /// @dev Verifies a Semaphore proof. Reverts with InvalidProof if the proof is invalid.
+  function verifyProof(
+    uint256[2] memory a,
+    uint256[2][2] memory b,
+    uint256[2] memory c,
+    uint256[4] memory input
+  ) public view {
+    // If the values are not in the correct range, the Pairing contract will revert.
+    Proof memory proof;
+    proof.A = Pairing.G1Point(a[0], a[1]);
+    proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
+    proof.C = Pairing.G1Point(c[0], c[1]);
+
+    VerifyingKey memory vk = verifyingKey();
+    
+    // Compute the linear combination vk_x of inputs times IC
+    if (input.length + 1 != vk.IC.length) revert Pairing.InvalidProof();
+    Pairing.G1Point memory vk_x = vk.IC[0];
+    <%_ for (let i=1; i < IC.length; i++) { _%>
+    vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[<%=i%>], input[<%=i - 1%>]));
+    <%_ } _%>
+ 
+    // Check pairing
+    Pairing.G1Point[] memory p1 = new Pairing.G1Point[](4);
+    Pairing.G2Point[] memory p2 = new Pairing.G2Point[](4);
+    p1[0] = Pairing.negate(proof.A);  p2[0] = proof.B;
+    p1[1] = vk.alfa1;                 p2[1] = vk.beta2;
+    p1[2] = vk_x;                     p2[2] = vk.gamma2;
+    p1[3] = proof.C;                  p2[3] = vk.delta2;
+    Pairing.pairingCheck(p1, p2);
+  }
 }


### PR DESCRIPTION
## What is the current behavior?

Currently when provided with an invalid proof, the verifier will either:

* return `false`,
* execute the `invalid()` opcode,
* revert with one of a variety of error messages, like
  * `verifier-gte-snark-scalar-field`
  * `pairing-add-failed`,
  * etc..

This makes handling invalid proofs hard. Returning `false` is especially dangerous because it puts the burden on the caller.

## What is the new behavior?

When provided with an invalid proof, the verifier will:

* revert with `InvalidProof()`

In the unlikely event that the caller desires different behaviour, the caller can use a Solidity try/catch statement. 

See also https://github.com/appliedzkp/semaphore/pull/96