### PR TITLE
fix: Update plonk GC call to use globalThis

### DIFF
--- a/src/plonk_setup.js
+++ b/src/plonk_setup.js
@@ -37,7 +37,7 @@ import BigArray from "./bigarray.js";
 
 export default async function plonkSetup(r1csName, ptauName, zkeyName, logger) {
 
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
 
     await Blake2b.ready();
 
@@ -62,7 +62,7 @@ export default async function plonkSetup(r1csName, ptauName, zkeyName, logger) {
     const nPublic = r1cs.nOutputs + r1cs.nPubInputs;
 
     await processConstraints();
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
 
     const fdZKey = await createBinFile(zkeyName, "zkey", 1, 14, 1<<22, 1<<24);
 
@@ -98,27 +98,27 @@ export default async function plonkSetup(r1csName, ptauName, zkeyName, logger) {
 
 
     await writeAdditions(3, "Additions");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeWitnessMap(4, 0, "Amap");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeWitnessMap(5, 1, "Bmap");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeWitnessMap(6, 2, "Cmap");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeQMap(7, 3, "Qm");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeQMap(8, 4, "Ql");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeQMap(9, 5, "Qr");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeQMap(10, 6, "Qo");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeQMap(11, 7, "Qc");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeSigma(12, "sigma");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
     await writeLs(13, "lagrange polynomials");
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
 
     // Write PTau points
     ////////////
@@ -128,7 +128,7 @@ export default async function plonkSetup(r1csName, ptauName, zkeyName, logger) {
     await fdPTau.readToBuffer(buffOut, 0, (domainSize+6)*sG1, sectionsPTau[2][0].p);
     await fdZKey.write(buffOut);
     await endWriteSection(fdZKey);
-    if (global.gc) {global.gc();}
+    if (globalThis.gc) {globalThis.gc();}
 
 
     await writeHeaders();
@@ -319,17 +319,17 @@ export default async function plonkSetup(r1csName, ptauName, zkeyName, logger) {
             }
             if ((logger)&&(s%1000000 == 0)) logger.debug(`writing ${name} phase2: ${s}/${plonkNVars}`);
         }
-    	if (global.gc) {global.gc();}
+    	if (globalThis.gc) {globalThis.gc();}
         await startWriteSection(fdZKey, sectionNum);
         let S1 = sigma.slice(0, domainSize*n8r);
         await writeP4(S1);
-    	if (global.gc) {global.gc();}
+    	if (globalThis.gc) {globalThis.gc();}
         let S2 = sigma.slice(domainSize*n8r, domainSize*n8r*2);
         await writeP4(S2);
-    	if (global.gc) {global.gc();}
+    	if (globalThis.gc) {globalThis.gc();}
         let S3 = sigma.slice(domainSize*n8r*2, domainSize*n8r*3);
         await writeP4(S3);
-    	if (global.gc) {global.gc();}
+    	if (globalThis.gc) {globalThis.gc();}
         await endWriteSection(fdZKey);
 
         S1 = await Fr.batchFromMontgomery(S1);
@@ -337,11 +337,11 @@ export default async function plonkSetup(r1csName, ptauName, zkeyName, logger) {
         S3 = await Fr.batchFromMontgomery(S3);
 
         vk.S1= await curve.G1.multiExpAffine(LPoints, S1, logger, "multiexp S1");
-    	if (global.gc) {global.gc();}
+    	if (globalThis.gc) {globalThis.gc();}
         vk.S2= await curve.G1.multiExpAffine(LPoints, S2, logger, "multiexp S2");
-    	if (global.gc) {global.gc();}
+    	if (globalThis.gc) {globalThis.gc();}
         vk.S3= await curve.G1.multiExpAffine(LPoints, S3, logger, "multiexp S3");
-    	if (global.gc) {global.gc();}
+    	if (globalThis.gc) {globalThis.gc();}
 
         function buildSigma(s, p) {
             if (typeof lastAparence[s] === "undefined") {


### PR DESCRIPTION
Commit https://github.com/iden3/snarkjs/commit/f5ebdc1d08fc569f2f7310e093dfae108b312817 added `global.gc` calls for the `plonk_setup`. However, the `global` variable is not available in the browser. Converting this to `globalThis` will ensure this works in nodejs and the browser.