### PR TITLE
Jump to correct Section when using PLONK

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Groth16 requires a trusted ceremony for each circuit. PLONK does not require it,
 snarkjs plonk setup circuit.r1cs pot12_final.ptau circuit_final.zkey
 ```
 
-You can jump directly to Section 21 as PLONK does not require a specific trusted ceremony.
+You can jump directly to Section 22 as PLONK does not require a specific trusted ceremony.
 
 #### Groth16
 ```sh


### PR DESCRIPTION
when you try to run `snarkjs zkey verify` on a plonk zkey, it returns `Error: zkey file is not groth16`
I suppose there is no nee to verify the circuit_final.zkey file when using PLONK, so the correct section jump would be 22 (not 21)