### PR TITLE
fix: Ensure zkey import bellman command exits with correct code

### DIFF
--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -8740,7 +8740,12 @@ async function zkeyImportBellman(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return phase2importMPCParams(zkeyNameOld, mpcParamsName, zkeyNameNew, options.name, logger);
+    const isValid = await phase2importMPCParams(zkeyNameOld, mpcParamsName, zkeyNameNew, options.name, logger);
+    if (isValid) {
+        return 0;
+    } else {
+        return 1;
+    }
 }
 
 // phase2 verify r1cs [circuit.r1cs] [powersoftau.ptau] [circuit_final.zkey]

--- a/cli.js
+++ b/cli.js
@@ -874,7 +874,12 @@ async function zkeyImportBellman(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return zkey.importBellman(zkeyNameOld, mpcParamsName, zkeyNameNew, options.name, logger);
+    const isValid = await zkey.importBellman(zkeyNameOld, mpcParamsName, zkeyNameNew, options.name, logger);
+    if (isValid) {
+        return 0;
+    } else {
+        return 1;
+    }
 }
 
 // phase2 verify r1cs [circuit.r1cs] [powersoftau.ptau] [circuit_final.zkey]


### PR DESCRIPTION
I debugged the failures in the "test tutorial" CI and found that the `zkey.importBellman` function returns true if the import was successful. Returning `true` is the same as returning `1` to the CLI tool, which causes an incorrect exit. We need to check that the `isValid` return is true and then return a `0` exit code, like other functions.