### PR TITLE
fix: Remove readline module, as we expects the nodejs internal module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "ffjavascript": "0.2.55",
         "js-sha3": "^0.8.0",
         "logplease": "^1.2.15",
-        "r1csfile": "0.0.36",
-        "readline": "^1.3.0"
+        "r1csfile": "0.0.36"
       },
       "bin": {
         "snarkjs": "build/cli.cjs"
@@ -1926,11 +1925,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/readline": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
-      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -3928,11 +3922,6 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
-    },
-    "readline": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
-      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw="
     },
     "regexpp": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "ffjavascript": "0.2.55",
     "js-sha3": "^0.8.0",
     "logplease": "^1.2.15",
-    "r1csfile": "0.0.36",
-    "readline": "^1.3.0"
+    "r1csfile": "0.0.36"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",


### PR DESCRIPTION
Fixes #87 

I was looking at the readline module from npm and it doesn't even have the same API as nodejs (so it's not a shim). The code that expects readline in snarkjs is just broken right now.

I'm not sure of a good way to add a regression test for this.