### PR TITLE
fix: Use bfj library to stringify JSON in CLI commands

### DIFF
--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -15,6 +15,7 @@ var binFileUtils = require('@iden3/binfileutils');
 var ejs = require('ejs');
 var circom_runtime = require('circom_runtime');
 var jsSha3 = require('js-sha3');
+var bfj = require('bfj');
 var Logger = require('logplease');
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
@@ -47,6 +48,7 @@ var path__default = /*#__PURE__*/_interopDefaultLegacy(path);
 var binFileUtils__namespace = /*#__PURE__*/_interopNamespace(binFileUtils);
 var ejs__default = /*#__PURE__*/_interopDefaultLegacy(ejs);
 var jsSha3__default = /*#__PURE__*/_interopDefaultLegacy(jsSha3);
+var bfj__default = /*#__PURE__*/_interopDefaultLegacy(bfj);
 var Logger__default = /*#__PURE__*/_interopDefaultLegacy(Logger);
 
 /*
@@ -8247,8 +8249,7 @@ async function r1csExportJSON(params, options) {
 
     const r1csObj = await r1csExportJson(r1csName, logger);
 
-    const S = JSON.stringify(r1csObj, null, 1);
-    await fs__default["default"].promises.writeFile(jsonName, S);
+    await bfj__default["default"].write(jsonName, r1csObj, { space: 1 });
 
     return 0;
 }
@@ -8297,7 +8298,7 @@ async function wtnsExportJson(params, options) {
 
     const w = await wtnsExportJson$1(wtnsName);
 
-    await fs__default["default"].promises.writeFile(jsonName, JSON.stringify(stringifyBigInts(w), null, 1));
+    await bfj__default["default"].write(jsonName, stringifyBigInts(w), { space: 1 });
 
     return 0;
 }
@@ -8319,9 +8320,9 @@ async function zksnarkSetup(params, options) {
     const setup = zkSnark[protocol].setup(cir, options.verbose);
 
     await zkey.utils.write(zkeyName, setup.vk_proof);
-    // await fs.promises.writeFile(provingKeyName, JSON.stringify(stringifyBigInts(setup.vk_proof), null, 1), "utf-8");
+    await bfj.write(provingKeyName, stringifyBigInts(setup.vk_proof), { space: 1 });
 
-    await fs.promises.writeFile(verificationKeyName, JSON.stringify(stringifyBigInts(setup.vk_verifier), null, 1), "utf-8");
+    await bfj.write(verificationKeyName, stringifyBigInts(setup.vk_verifier), { space: 1 });
 
     return 0;
 }
@@ -8339,8 +8340,8 @@ async function groth16Prove(params, options) {
 
     const {proof, publicSignals} = await groth16Prove$1(zkeyName, witnessName, logger);
 
-    await fs__default["default"].promises.writeFile(proofName, JSON.stringify(stringifyBigInts(proof), null, 1), "utf-8");
-    await fs__default["default"].promises.writeFile(publicName, JSON.stringify(stringifyBigInts(publicSignals), null, 1), "utf-8");
+    await bfj__default["default"].write(proofName, stringifyBigInts(proof), { space: 1 });
+    await bfj__default["default"].write(publicName, stringifyBigInts(publicSignals), { space: 1 });
 
     return 0;
 }
@@ -8360,8 +8361,8 @@ async function groth16FullProve(params, options) {
 
     const {proof, publicSignals} = await groth16FullProve$1(input, wasmName, zkeyName,  logger);
 
-    await fs__default["default"].promises.writeFile(proofName, JSON.stringify(stringifyBigInts(proof), null, 1), "utf-8");
-    await fs__default["default"].promises.writeFile(publicName, JSON.stringify(stringifyBigInts(publicSignals), null, 1), "utf-8");
+    await bfj__default["default"].write(proofName, stringifyBigInts(proof), { space: 1 });
+    await bfj__default["default"].write(publicName, stringifyBigInts(publicSignals), { space: 1 });
 
     return 0;
 }
@@ -8397,8 +8398,7 @@ async function zkeyExportVKey(params, options) {
 
     const vKey = await zkeyExportVerificationKey(zkeyName);
 
-    const S = JSON.stringify(ffjavascript.utils.stringifyBigInts(vKey), null, 1);
-    await fs__default["default"].promises.writeFile(verificationKeyName, S);
+    await bfj__default["default"].write(verificationKeyName, stringifyBigInts(vKey), { space: 1 });
 }
 
 // zkey export json [circuit_final.zkey] [circuit.zkey.json]",
@@ -8410,8 +8410,7 @@ async function zkeyExportJson(params, options) {
 
     const zKeyJson = await zkeyExportJson$1(zkeyName);
 
-    const S = JSON.stringify(zKeyJson, null, 1);
-    await fs__default["default"].promises.writeFile(zkeyJsonName, S);
+    await bfj__default["default"].write(zkeyJsonName, zKeyJson, { space: 1 });
 }
 
 async function fileExists(file) {
@@ -8674,9 +8673,7 @@ async function powersOfTauExportJson(params, options) {
 
     const pTauJson = await exportJson(ptauName, logger);
 
-    const S = JSON.stringify(pTauJson, null, 1);
-    await fs__default["default"].promises.writeFile(jsonName, S);
-
+    await bfj__default["default"].write(jsonName, pTauJson, { space: 1 });
 }
 
 
@@ -8912,8 +8909,8 @@ async function plonkProve(params, options) {
 
     const {proof, publicSignals} = await plonk16Prove(zkeyName, witnessName, logger);
 
-    await fs__default["default"].promises.writeFile(proofName, JSON.stringify(stringifyBigInts(proof), null, 1), "utf-8");
-    await fs__default["default"].promises.writeFile(publicName, JSON.stringify(stringifyBigInts(publicSignals), null, 1), "utf-8");
+    await bfj__default["default"].write(proofName, stringifyBigInts(proof), { space: 1 });
+    await bfj__default["default"].write(publicName, stringifyBigInts(publicSignals), { space: 1 });
 
     return 0;
 }
@@ -8934,8 +8931,8 @@ async function plonkFullProve(params, options) {
 
     const {proof, publicSignals} = await plonkFullProve$1(input, wasmName, zkeyName,  logger);
 
-    await fs__default["default"].promises.writeFile(proofName, JSON.stringify(stringifyBigInts(proof), null, 1), "utf-8");
-    await fs__default["default"].promises.writeFile(publicName, JSON.stringify(stringifyBigInts(publicSignals), null, 1), "utf-8");
+    await bfj__default["default"].write(proofName, stringifyBigInts(proof), { space: 1 });
+    await bfj__default["default"].write(publicName, stringifyBigInts(publicSignals), { space: 1 });
 
     return 0;
 }

--- a/cli.js
+++ b/cli.js
@@ -40,6 +40,7 @@ import * as plonk from "./src/plonk.js";
 import * as wtns from "./src/wtns.js";
 import * as curves from "./src/curves.js";
 import path from "path";
+import bfj from "bfj";
 
 import Logger from "logplease";
 const logger = Logger.create("snarkJS", {showTimestamp:false});
@@ -380,8 +381,7 @@ async function r1csExportJSON(params, options) {
 
     const r1csObj = await r1cs.exportJson(r1csName, logger);
 
-    const S = JSON.stringify(r1csObj, null, 1);
-    await fs.promises.writeFile(jsonName, S);
+    await bfj.write(jsonName, r1csObj, { space: 1 });
 
     return 0;
 }
@@ -430,7 +430,7 @@ async function wtnsExportJson(params, options) {
 
     const w = await wtns.exportJson(wtnsName);
 
-    await fs.promises.writeFile(jsonName, JSON.stringify(stringifyBigInts(w), null, 1));
+    await bfj.write(jsonName, stringifyBigInts(w), { space: 1 });
 
     return 0;
 }
@@ -452,9 +452,9 @@ async function zksnarkSetup(params, options) {
     const setup = zkSnark[protocol].setup(cir, options.verbose);
 
     await zkey.utils.write(zkeyName, setup.vk_proof);
-    // await fs.promises.writeFile(provingKeyName, JSON.stringify(stringifyBigInts(setup.vk_proof), null, 1), "utf-8");
+    await bfj.write(provingKeyName, stringifyBigInts(setup.vk_proof), { space: 1 });
 
-    await fs.promises.writeFile(verificationKeyName, JSON.stringify(stringifyBigInts(setup.vk_verifier), null, 1), "utf-8");
+    await bfj.write(verificationKeyName, stringifyBigInts(setup.vk_verifier), { space: 1 });
 
     return 0;
 }
@@ -472,8 +472,8 @@ async function groth16Prove(params, options) {
 
     const {proof, publicSignals} = await groth16.prove(zkeyName, witnessName, logger);
 
-    await fs.promises.writeFile(proofName, JSON.stringify(stringifyBigInts(proof), null, 1), "utf-8");
-    await fs.promises.writeFile(publicName, JSON.stringify(stringifyBigInts(publicSignals), null, 1), "utf-8");
+    await bfj.write(proofName, stringifyBigInts(proof), { space: 1 });
+    await bfj.write(publicName, stringifyBigInts(publicSignals), { space: 1 });
 
     return 0;
 }
@@ -493,8 +493,8 @@ async function groth16FullProve(params, options) {
 
     const {proof, publicSignals} = await groth16.fullProve(input, wasmName, zkeyName,  logger);
 
-    await fs.promises.writeFile(proofName, JSON.stringify(stringifyBigInts(proof), null, 1), "utf-8");
-    await fs.promises.writeFile(publicName, JSON.stringify(stringifyBigInts(publicSignals), null, 1), "utf-8");
+    await bfj.write(proofName, stringifyBigInts(proof), { space: 1 });
+    await bfj.write(publicName, stringifyBigInts(publicSignals), { space: 1 });
 
     return 0;
 }
@@ -530,8 +530,7 @@ async function zkeyExportVKey(params, options) {
 
     const vKey = await zkey.exportVerificationKey(zkeyName);
 
-    const S = JSON.stringify(utils.stringifyBigInts(vKey), null, 1);
-    await fs.promises.writeFile(verificationKeyName, S);
+    await bfj.write(verificationKeyName, stringifyBigInts(vKey), { space: 1 });
 }
 
 // zkey export json [circuit_final.zkey] [circuit.zkey.json]",
@@ -543,8 +542,7 @@ async function zkeyExportJson(params, options) {
 
     const zKeyJson = await zkey.exportJson(zkeyName, logger);
 
-    const S = JSON.stringify(zKeyJson, null, 1);
-    await fs.promises.writeFile(zkeyJsonName, S);
+    await bfj.write(zkeyJsonName, zKeyJson, { space: 1 });
 }
 
 async function fileExists(file) {
@@ -807,9 +805,7 @@ async function powersOfTauExportJson(params, options) {
 
     const pTauJson = await powersOfTau.exportJson(ptauName, logger);
 
-    const S = JSON.stringify(pTauJson, null, 1);
-    await fs.promises.writeFile(jsonName, S);
-
+    await bfj.write(jsonName, pTauJson, { space: 1 });
 }
 
 
@@ -1045,8 +1041,8 @@ async function plonkProve(params, options) {
 
     const {proof, publicSignals} = await plonk.prove(zkeyName, witnessName, logger);
 
-    await fs.promises.writeFile(proofName, JSON.stringify(stringifyBigInts(proof), null, 1), "utf-8");
-    await fs.promises.writeFile(publicName, JSON.stringify(stringifyBigInts(publicSignals), null, 1), "utf-8");
+    await bfj.write(proofName, stringifyBigInts(proof), { space: 1 });
+    await bfj.write(publicName, stringifyBigInts(publicSignals), { space: 1 });
 
     return 0;
 }
@@ -1067,8 +1063,8 @@ async function plonkFullProve(params, options) {
 
     const {proof, publicSignals} = await plonk.fullProve(input, wasmName, zkeyName,  logger);
 
-    await fs.promises.writeFile(proofName, JSON.stringify(stringifyBigInts(proof), null, 1), "utf-8");
-    await fs.promises.writeFile(publicName, JSON.stringify(stringifyBigInts(publicSignals), null, 1), "utf-8");
+    await bfj.write(proofName, stringifyBigInts(proof), { space: 1 });
+    await bfj.write(publicName, stringifyBigInts(publicSignals), { space: 1 });
 
     return 0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@iden3/binfileutils": "0.0.11",
+        "bfj": "^7.0.2",
         "blake2b-wasm": "^2.4.0",
         "circom_runtime": "0.1.18",
         "ejs": "^3.1.6",
@@ -436,6 +437,20 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/bfj": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
+      "integrity": "sha512-+e/UqUzwmzJamNF50tBV6tZPTORow7gQ96iFow+8b562OdMpEK0BcJEq2OSPEDmAbSMBQ7PKZ87ubFkgxpYWgw==",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "check-types": "^11.1.1",
+        "hoopy": "^0.1.4",
+        "tryer": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -466,6 +481,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -574,6 +594,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/check-types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
+      "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -1226,6 +1251,14 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ignore": {
@@ -2277,6 +2310,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2797,6 +2835,17 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "bfj": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.0.2.tgz",
+      "integrity": "sha512-+e/UqUzwmzJamNF50tBV6tZPTORow7gQ96iFow+8b562OdMpEK0BcJEq2OSPEDmAbSMBQ7PKZ87ubFkgxpYWgw==",
+      "requires": {
+        "bluebird": "^3.5.5",
+        "check-types": "^11.1.1",
+        "hoopy": "^0.1.4",
+        "tryer": "^1.0.1"
+      }
+    },
     "big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
@@ -2821,6 +2870,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2899,6 +2953,11 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
+    },
+    "check-types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
+      "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
     },
     "chokidar": {
       "version": "3.5.3",
@@ -3391,6 +3450,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "ignore": {
       "version": "5.2.0",
@@ -4174,6 +4238,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@iden3/binfileutils": "0.0.11",
     "blake2b-wasm": "^2.4.0",
+    "bfj": "^7.0.2",
     "circom_runtime": "0.1.18",
     "ejs": "^3.1.6",
     "fastfile": "0.0.20",


### PR DESCRIPTION
Fixes #193 (and a whole set of related issues when trying to serialize large data sets).

I think we probably should use `bfj` to read JSON too so these large files can be loaded again, but I need to work with someone to test that.