### PR TITLE
fix: r1csPrint does not print a constant '1' or '-1'

### DIFF
--- a/src/r1cs_print.js
+++ b/src/r1cs_print.js
@@ -30,8 +30,8 @@ export default function r1csPrint(r1cs, syms, logger) {
                 if (name == "one") name = "";
 
                 let vs = r1cs.curve.Fr.toString(lc[k]);
-                if (vs == "1") vs = "";  // Do not show ones
-                if (vs == "-1") vs = "-";  // Do not show ones
+                if ((vs == "1")&&(name != "")) vs = "";  // Do not show ones
+                if ((vs == "-1")&&(name != "")) vs = "-";  // Do not show ones
                 if ((S!="")&&(vs[0]!="-")) vs = "+"+vs;
                 if (S!="") vs = " "+vs;
                 S= S + vs   + name;


### PR DESCRIPTION
r1csPrint does not print a constant '1' or '-1'  in the constraints which leads to printing wrong constraints. For example encoding a simple multiplexer: 

$$f(s) = \begin{cases} 1 & if ~~ s = 0\\
 a & if ~~ s = 1\end{cases} $$

can be represented as the following circom code: 

```
pragma circom 2.0.0;
template test(){
    signal input a;
    signal input s;
    signal output out;

    (s) * (s - 1) === 0; //check that s is binary
    out <== 1 + s * (a - 1);

}

component main {public [a, s]} = test();
```
After compiling it using the following command
```js
circom --wasm --sym --r1cs --json  test.circom
```

To show the constraints, I used the command ```snarkjs```

```js
snarkjs r1cs print test.r1cs test.sym
```
and the output was:

```
[INFO]  snarkJS: [ 21888242871839275222246405745257275088548364400416034343698204186575808495616 +main.s ] * [ main.s ] - [  ] = 0
[INFO]  snarkJS: [ 21888242871839275222246405745257275088548364400416034343698204186575808495616main.a ] * [ main.s ] - [ 21888242871839275222246405745257275088548364400416034343698204186575808495616main.out ] = 0
```

Since the used prime $p = 21888242871839275222246405745257275088548364400416034343698204186575808495617$, so $21888242871839275222246405745257275088548364400416034343698204186575808495616 \equiv -1 \mod p$ 

and the constraints will be
```
[ -1 +main.s ] * [ main.s ] - [  ] = 0 
[ -1main.a ] * [ main.s ] - [ -1main.out ] = 0 
```
which equivalent to

$$ (s -1) \times s = 0$$ 

$$ a \times s - out = 0$$

The first constraint is correct and the second one is not correct.

Based on json file generated by circom, the constraints are

```json
{
"constraints": [
[{"0":"21888242871839275222246405745257275088548364400416034343698204186575808495616","3":"1"},{"3":"1"},{}],
[{"0":"1","2":"21888242871839275222246405745257275088548364400416034343698204186575808495616"},{"3":"1"},{"0":"1","1":"21888242871839275222246405745257275088548364400416034343698204186575808495616"}]
]
}
```
Therefore, the constraints should be printed as 

```
[INFO]  snarkJS: [ 21888242871839275222246405745257275088548364400416034343698204186575808495616 +main.s ] * [ main.s ] - [  ] = 0
[INFO]  snarkJS: [ 1 +21888242871839275222246405745257275088548364400416034343698204186575808495616main.a ] * [ main.s ] - [ 1 +21888242871839275222246405745257275088548364400416034343698204186575808495616main.out ] = 0
```

This PR solves this problem
