### PR TITLE
Refactor: use bitwise shift for round a number down more quickly

### DIFF
--- a/src/bigarray.js
+++ b/src/bigarray.js
@@ -58,13 +58,13 @@ class _BigArray {
     }
     getElement(idx) {
         idx = parseInt(idx);
-        const idx1 = Math.floor(idx / SUBARRAY_SIZE);
+        const idx1 = ~~(idx / SUBARRAY_SIZE);
         const idx2 = idx % SUBARRAY_SIZE;
         return this.arr[idx1] ? this.arr[idx1][idx2] : undefined;
     }
     setElement(idx, value) {
         idx = parseInt(idx);
-        const idx1 = Math.floor(idx / SUBARRAY_SIZE);
+        const idx1 = ~~(idx / SUBARRAY_SIZE);
         if (!this.arr[idx1]) {
             this.arr[idx1] = new Array(SUBARRAY_SIZE);
         }

--- a/src/groth16_prove.js
+++ b/src/groth16_prove.js
@@ -200,7 +200,7 @@ async function buldABC(curve, zkey, witness, coeffs, logger) {
             coeffsDV.push(new DataView(coeffs.buffers[i].buffer));
         }
         getUint32 = function (pos) {
-            return coeffsDV[Math.floor(pos/PAGE_LEN)].getUint32(pos % PAGE_LEN, true);
+            return coeffsDV[~~(pos/PAGE_LEN)].getUint32(pos % PAGE_LEN, true);
         };
     } else {
         const coeffsDV = new DataView(coeffs.buffer, coeffs.byteOffset, coeffs.byteLength);
@@ -209,12 +209,12 @@ async function buldABC(curve, zkey, witness, coeffs, logger) {
         };
     }
 
-    const elementsPerChunk = Math.floor(zkey.domainSize/concurrency);
+    const elementsPerChunk = ~~(zkey.domainSize/concurrency);
     const promises = [];
 
     const cutPoints = [];
     for (let i=0; i<concurrency; i++) {
-        cutPoints.push( getCutPoint( Math.floor(i*elementsPerChunk) ));
+        cutPoints.push( getCutPoint( ~~(i*elementsPerChunk) ));
     }
     cutPoints.push(coeffs.byteLength);
 
@@ -302,7 +302,7 @@ async function buldABC(curve, zkey, witness, coeffs, logger) {
         let m = 0;
         let n = getUint32(0);
         while (m < n) {
-            var k = Math.floor((n + m) / 2);
+            var k = ~~((n + m) / 2);
             const va = getUint32(4 + k*sCoef + 4);
             if (va > v) {
                 n = k - 1;
@@ -321,7 +321,7 @@ async function joinABC(curve, zkey, a, b, c, logger) {
     const MAX_CHUNK_SIZE = 1 << 22;
 
     const n8 = curve.Fr.n8;
-    const nElements = Math.floor(a.byteLength / curve.Fr.n8);
+    const nElements = ~~(a.byteLength / curve.Fr.n8);
 
     const promises = [];
 

--- a/src/mpc_applykey.js
+++ b/src/mpc_applykey.js
@@ -55,7 +55,7 @@ export async function applyKeyToSection(fdOld, sections, fdNew, idSection, curve
 export async function applyKeyToChallengeSection(fdOld, fdNew, responseHasher, curve, groupName, nPoints, first, inc, formatOut, sectionName, logger) {
     const G = curve[groupName];
     const sG = G.F.n8*2;
-    const chunkSize = Math.floor((1<<20) / sG);   // 128Mb chunks
+    const chunkSize = ~~((1<<20) / sG);   // 128Mb chunks
     let t = first;
     for (let i=0 ; i<nPoints ; i+= chunkSize) {
         if (logger) logger.debug(`Applying key ${sectionName}: ${i}/${nPoints}`);

--- a/src/plonk_setup.js
+++ b/src/plonk_setup.js
@@ -448,10 +448,10 @@ export default async function plonkSetup(r1csName, ptauName, zkeyName, logger) {
 
         await startWriteSection(fdZKey, 2);
         const primeQ = curve.q;
-        const n8q = (Math.floor( (Scalar.bitLength(primeQ) - 1) / 64) +1)*8;
+        const n8q = (~~( (Scalar.bitLength(primeQ) - 1) / 64) +1)*8;
 
         const primeR = curve.r;
-        const n8r = (Math.floor( (Scalar.bitLength(primeR) - 1) / 64) +1)*8;
+        const n8r = (~~( (Scalar.bitLength(primeR) - 1) / 64) +1)*8;
 
         await fdZKey.writeULE32(n8q);
         await writeBigInt(fdZKey, primeQ, n8q);

--- a/src/powersoftau_beacon.js
+++ b/src/powersoftau_beacon.js
@@ -134,7 +134,7 @@ export default async function beacon(oldPtauFilename, newPTauFilename, name,  be
 
         const G = curve[groupName];
         const sG = G.F.n8*2;
-        const chunkSize = Math.floor((1<<20) / sG);   // 128Mb chunks
+        const chunkSize = ~~((1<<20) / sG);   // 128Mb chunks
         let t = first;
         for (let i=0 ; i<NPoints ; i+= chunkSize) {
             if (logger) logger.debug(`applying key${sectionName}: ${i}/${NPoints}`);
@@ -170,7 +170,7 @@ export default async function beacon(oldPtauFilename, newPTauFilename, name,  be
 
         const G = curve[groupName];
         const sG = G.F.n8*2;
-        const nPointsChunk = Math.floor((1<<24)/sG);
+        const nPointsChunk = ~~((1<<24)/sG);
 
         const oldPos = fdTo.pos;
         fdTo.pos = startSections[sectionId];

--- a/src/powersoftau_contribute.js
+++ b/src/powersoftau_contribute.js
@@ -127,7 +127,7 @@ export default async function contribute(oldPtauFilename, newPTauFilename, name,
 
         const G = curve[groupName];
         const sG = G.F.n8*2;
-        const chunkSize = Math.floor((1<<20) / sG);   // 128Mb chunks
+        const chunkSize = ~~((1<<20) / sG);   // 128Mb chunks
         let t = first;
         for (let i=0 ; i<NPoints ; i+= chunkSize) {
             if (logger) logger.debug(`processing: ${sectionName}: ${i}/${NPoints}`);
@@ -163,7 +163,7 @@ export default async function contribute(oldPtauFilename, newPTauFilename, name,
 
         const G = curve[groupName];
         const sG = G.F.n8*2;
-        const nPointsChunk = Math.floor((1<<24)/sG);
+        const nPointsChunk = ~~((1<<24)/sG);
 
         const oldPos = fdTo.pos;
         fdTo.pos = startSections[sectionId];

--- a/src/powersoftau_export_challenge.js
+++ b/src/powersoftau_export_challenge.js
@@ -62,7 +62,7 @@ export default async function exportChallenge(pTauFilename, challengeFilename, l
     async function exportSection(sectionId, groupName, nPoints, sectionName) {
         const G = curve[groupName];
         const sG = G.F.n8*2;
-        const nPointsChunk = Math.floor((1<<24)/sG);
+        const nPointsChunk = ~~((1<<24)/sG);
 
         await binFileUtils.startReadUniqueSection(fdFrom, sections, sectionId);
         for (let i=0; i< nPoints; i+= nPointsChunk) {

--- a/src/powersoftau_import.js
+++ b/src/powersoftau_import.js
@@ -147,7 +147,7 @@ export default async function importResponse(oldPtauFilename, contributionFilena
         const singularPoints = [];
 
         await binFileUtils.startWriteSection(fdTo, sectionId);
-        const nPointsChunk = Math.floor((1<<24)/sG);
+        const nPointsChunk = ~~((1<<24)/sG);
 
         startSections[sectionId] = fdTo.pos;
 
@@ -183,7 +183,7 @@ export default async function importResponse(oldPtauFilename, contributionFilena
 
         const singularPoints = [];
 
-        const nPointsChunk = Math.floor((1<<24)/scG);
+        const nPointsChunk = ~~((1<<24)/scG);
 
         for (let i=0; i< nPoints; i += nPointsChunk) {
             if (logger) logger.debug(`Importing ${sectionName}: ${i}/${nPoints}`);
@@ -209,7 +209,7 @@ export default async function importResponse(oldPtauFilename, contributionFilena
 
         const G = curve[groupName];
         const sG = G.F.n8*2;
-        const nPointsChunk = Math.floor((1<<24)/sG);
+        const nPointsChunk = ~~((1<<24)/sG);
 
         const oldPos = fdTo.pos;
         fdTo.pos = startSections[sectionId];

--- a/src/powersoftau_utils.js
+++ b/src/powersoftau_utils.js
@@ -342,7 +342,7 @@ export function calculateFirstChallengeHash(curve, power, logger) {
         // this block size is a good compromise between speed and the maximum
         // input size of the Blake2b update method (65,535,720 bytes).
         const blockSize = 341000;
-        const nBlocks = Math.floor(n / blockSize);
+        const nBlocks = ~~(n / blockSize);
         const rem = n % blockSize;
         const bigBuff = new Uint8Array(blockSize * buff.byteLength);
         for (let i=0; i<blockSize; i++) {

--- a/src/wtns_utils.js
+++ b/src/wtns_utils.js
@@ -25,7 +25,7 @@ import * as binFileUtils from "@iden3/binfileutils";
 export async function write(fd, witness, prime) {
 
     await binFileUtils.startWriteSection(fd, 1);
-    const n8 = (Math.floor( (Scalar.bitLength(prime) - 1) / 64) +1)*8;
+    const n8 = (~~( (Scalar.bitLength(prime) - 1) / 64) +1)*8;
     await fd.writeULE32(n8);
     await binFileUtils.writeBigInt(fd, prime, n8);
     await fd.writeULE32(witness.length);
@@ -43,7 +43,7 @@ export async function write(fd, witness, prime) {
 export async function writeBin(fd, witnessBin, prime) {
 
     await binFileUtils.startWriteSection(fd, 1);
-    const n8 = (Math.floor( (Scalar.bitLength(prime) - 1) / 64) +1)*8;
+    const n8 = (~~( (Scalar.bitLength(prime) - 1) / 64) +1)*8;
     await fd.writeULE32(n8);
     await binFileUtils.writeBigInt(fd, prime, n8);
     if (witnessBin.byteLength % n8 != 0) {

--- a/src/zkey_new.js
+++ b/src/zkey_new.js
@@ -83,10 +83,10 @@ export default async function newZKey(r1csName, ptauName, zkeyName, logger) {
 
     await startWriteSection(fdZKey, 2);
     const primeQ = curve.q;
-    const n8q = (Math.floor( (Scalar.bitLength(primeQ) - 1) / 64) +1)*8;
+    const n8q = (~~( (Scalar.bitLength(primeQ) - 1) / 64) +1)*8;
 
     const primeR = curve.r;
-    const n8r = (Math.floor( (Scalar.bitLength(primeR) - 1) / 64) +1)*8;
+    const n8r = (~~( (Scalar.bitLength(primeR) - 1) / 64) +1)*8;
     const Rr = Scalar.mod(Scalar.shl(1, n8r*8), primeR);
     const R2r = curve.Fr.e(Scalar.mod(Scalar.mul(Rr,Rr), primeR));
 
@@ -518,7 +518,7 @@ export default async function newZKey(r1csName, ptauName, zkeyName, logger) {
         const buff1 = await fdPTau.read(nPoints *sG1, sectionsPTau[2][0].p + (offset + domainSize)*sG1);
         const buff2 = await fdPTau.read(nPoints *sG1, sectionsPTau[2][0].p + offset*sG1);
         const concurrency= curve.tm.concurrency;
-        const nPointsPerThread = Math.floor(nPoints / concurrency);
+        const nPointsPerThread = ~~(nPoints / concurrency);
         const opPromises = [];
         for (let i=0; i<concurrency; i++) {
             let n;

--- a/src/zkey_utils.js
+++ b/src/zkey_utils.js
@@ -65,10 +65,10 @@ export async function writeHeader(fd, zkey) {
 
     await binFileUtils.startWriteSection(fd, 2);
     const primeQ = curve.q;
-    const n8q = (Math.floor( (Scalar.bitLength(primeQ) - 1) / 64) +1)*8;
+    const n8q = (~~( (Scalar.bitLength(primeQ) - 1) / 64) +1)*8;
 
     const primeR = curve.r;
-    const n8r = (Math.floor( (Scalar.bitLength(primeR) - 1) / 64) +1)*8;
+    const n8r = (~~( (Scalar.bitLength(primeR) - 1) / 64) +1)*8;
 
     await fd.writeULE32(n8q);
     await binFileUtils.writeBigInt(fd, primeQ, n8q);
@@ -96,7 +96,7 @@ export async function writeZKey(fileName, zkey) {
     const fd = await binFileUtils.createBinFile(fileName,"zkey", 1, 9);
 
     await writeHeader(fd, zkey);
-    const n8r = (Math.floor( (Scalar.bitLength(zkey.r) - 1) / 64) +1)*8;
+    const n8r = (~~( (Scalar.bitLength(zkey.r) - 1) / 64) +1)*8;
     const Rr = Scalar.mod(Scalar.shl(1, n8r*8), zkey.r);
     const R2r = Scalar.mod(Scalar.mul(Rr,Rr), zkey.r);
 

--- a/src/zkey_verify_frominit.js
+++ b/src/zkey_verify_frominit.js
@@ -358,7 +358,7 @@ export default async function phase2verifyFromInit(initFileName, pTauFileName, z
         const sG = curve.G1.F.n8*2;
         const nPoints = buff1.byteLength / sG;
         const concurrency= curve.tm.concurrency;
-        const nPointsPerThread = Math.floor(nPoints / concurrency);
+        const nPointsPerThread = ~~(nPoints / concurrency);
         const opPromises = [];
         for (let i=0; i<concurrency; i++) {
             let n;


### PR DESCRIPTION
bitwise shift is more efficient and these method is fastest in the various browsers.
its maybe make apps more effective. 