### PR TITLE
fix: check power is number

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -638,7 +638,7 @@ async function powersOfTauNew(params, options) {
     curveName = params[0];
 
     power = parseInt(params[1]);
-    if ((power<1) || (power>28)) {
+    if ((power<1) || (power>28) || isNaN(power)) {
         throw new Error("Power must be between 1 and 28");
     }
 


### PR DESCRIPTION
`power` argument is checked if it fits within the range while this check pass for `NaN`, which I suppose is not valid.
Also generated file contains `NaN` in the name.

Steps to reproduce:
`snarkjs powersoftau new bn128 new.ptau`

output:
`powersOfTauNaN_0000.ptau`

Generated file cannot be also exported to json:
```
snarkjs ptej powersOfTauNaN_0000.ptau powers.json

[ERROR] snarkJS: Error: Invalid section size reading

    at Object.endReadSection (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/node_modules/@iden3/binfileutils/build/main.cjs:107:74)

    at exportSection (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/build/cli.cjs:2950:39)

    at async exportJson (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/build/cli.cjs:2922:18)

    at async Object.powersOfTauExportJson [as action] (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/build/cli.cjs:8792:22)

    at async clProcessor (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/build/cli.cjs:454:27)
```

But I'm not sure if this is directly connected to the issue described here, because properly generated file cannot be exported also but with different error:

```
snarkjs powersoftau new bn128 12 new2.ptau       
[INFO]  snarkJS: First Contribution Hash:
		9e63a5f6 2b96538d aaed2372 481920d1
		a40b9195 9ea38ef9 f5f6a303 3b886516
		0710d067 c09d0961 5f928ea5 17bcdf49
		ad75abd2 c8340b40 0e3b18e9 68b4ffef
snarkjs ptej new2.ptau powers.json
[ERROR] snarkJS: Error: new2.ptau: Missing section 12
    at Object.startReadUniqueSection (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/node_modules/@iden3/binfileutils/build/main.cjs:96:38)
    at exportLagrange (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/build/cli.cjs:2960:39)
    at exportJson (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/build/cli.cjs:2928:25)
    at async Object.powersOfTauExportJson [as action] (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/build/cli.cjs:8792:22)
    at async clProcessor (/Users/kziemianek/.nvm/versions/node/v18.8.0/lib/node_modules/snarkjs/build/cli.cjs:454:27)
```