### PR TITLE
Update groth16 verifier template

### DIFF
--- a/templates/verifier_groth16.sol.ejs
+++ b/templates/verifier_groth16.sol.ejs
@@ -247,4 +247,10 @@ contract Verifier {
             return false;
         }
     }
+
+    /// @notice Function to get the number of public signals of the circom circuit
+    /// @return number of public signals
+    function getInputsNumber() public pure returns (uint256) {
+        return <%=IC.length-1%>;
+    }
 }


### PR DESCRIPTION
There are projects within which many different **circom** circuits are used. The [VerifierHelper](https://github.com/dl-solidity-library/dev-modules/blob/master/contracts/libs/zkp/snarkjs/VerifierHelper.sol) library was written to simplify and optimize work with the verifier contracts. In order to make the library more secure, you need to be able to get the number of public signals on-chain.

For this purpose the `getInputsNumber` function, which returns the number of public signals, was added to the verifier contract template.