### PR TITLE
Simplify the `verifyProof` return statement

### DIFF
--- a/templates/verifier_groth16.sol.ejs
+++ b/templates/verifier_groth16.sol.ejs
@@ -241,10 +241,6 @@ contract Verifier {
         for(uint i = 0; i < input.length; i++){
             inputValues[i] = input[i];
         }
-        if (verify(inputValues, proof) == 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return verify(inputValues, proof) == 0;
     }
 }


### PR DESCRIPTION
This PR simplifies the `verifyProof` return statement. We can just return a condition.
The current one would be a bit redundant.