### PR TITLE
fixes an issue where pairing raises an unexpected exception

### DIFF
--- a/templates/verifier_groth16.sol.ejs
+++ b/templates/verifier_groth16.sol.ejs
@@ -107,10 +107,9 @@ library Pairing {
         uint[1] memory out;
         bool success;
         // solium-disable-next-line security/no-inline-assembly
+        // precompiled bn128 curve pairing as per EIP197 - defined as contract "8"
         assembly {
             success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
-            // Use "invalid" to make gas estimation work
-            switch success case 0 { invalid() }
         }
         require(success,"pairing-opcode-failed");
         return out[0] != 0;


### PR DESCRIPTION
It appears that `switch success case 0 { invalid() }` causes a bug in the snarks solidity templates that emerges as

```
Transaction reverted: call to precompile 8 failed
```

when the curve pairing fails.

The following remix debug gives some more insight into this issue:

```json
{
	"error": "Failed to decode output: Error: hex data is odd-length (argument=\"value\", value=\"0x0\", code=INVALID_ARGUMENT, version=bytes/5.5.0)"
}
```

My guess is that the curve pairing returns `0x0` or `0x1` which cannot be handled inside the assembly.
