### PR TITLE
fix(cli): Correctly return status codes instead of values

### DIFF
--- a/build/cli.cjs
+++ b/build/cli.cjs
@@ -12913,7 +12913,10 @@ async function powersOfTauNew(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return await newAccumulator(curve, power, ptauName, logger);
+    // Discard firstChallengeHash
+    await newAccumulator(curve, power, ptauName, logger);
+
+    return 0;
 }
 
 async function powersOfTauExportChallenge(params, options) {
@@ -12930,7 +12933,10 @@ async function powersOfTauExportChallenge(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return await exportChallenge(ptauName, challengeName, logger);
+    // Discard curChallengeHash
+    await exportChallenge(ptauName, challengeName, logger);
+
+    return 0;
 }
 
 // powersoftau challenge contribute <curve> <challenge> [response]
@@ -12950,7 +12956,9 @@ async function powersOfTauChallengeContribute(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return await challengeContribute(curve, challengeName, responseName, options.entropy, logger);
+    await challengeContribute(curve, challengeName, responseName, options.entropy, logger);
+
+    return 0;
 }
 
 
@@ -12972,6 +12980,7 @@ async function powersOfTauImport(params, options) {
 
     const res = await importResponse(oldPtauName, response, newPtauName, options.name, importPoints, logger);
 
+    // TODO: This seems wrong
     if (res) return res;
     if (!doCheck) return;
 
@@ -13006,7 +13015,10 @@ async function powersOfTauBeacon(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return await beacon$1(oldPtauName, newPtauName, options.name, beaconHashStr, numIterationsExp, logger);
+    // Discard hashResponse
+    await beacon$1(oldPtauName, newPtauName, options.name, beaconHashStr, numIterationsExp, logger);
+
+    return 0;
 }
 
 async function powersOfTauContribute(params, options) {
@@ -13018,7 +13030,10 @@ async function powersOfTauContribute(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return await contribute(oldPtauName, newPtauName, options.name, options.entropy, logger);
+    // Discard hashResponse
+    await contribute(oldPtauName, newPtauName, options.name, options.entropy, logger);
+
+    return 0;
 }
 
 async function powersOfTauPreparePhase2(params, options) {
@@ -13030,7 +13045,9 @@ async function powersOfTauPreparePhase2(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return await preparePhase2(oldPtauName, newPtauName, logger);
+    await preparePhase2(oldPtauName, newPtauName, logger);
+
+    return 0;
 }
 
 async function powersOfTauConvert(params, options) {
@@ -13042,7 +13059,9 @@ async function powersOfTauConvert(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return await convert(oldPtauName, newPtauName, logger);
+    await convert(oldPtauName, newPtauName, logger);
+
+    return 0;
 }
 
 
@@ -13058,7 +13077,10 @@ async function powersOfTauTruncate(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return await truncate(ptauName, template, logger);
+    // Discard `true`
+    await truncate(ptauName, template, logger);
+
+    return 0;
 }
 
 // powersoftau export json <powersoftau_0000.ptau> <powersoftau_0000.json>",
@@ -13103,7 +13125,10 @@ async function zkeyNew(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return newZKey(r1csName, ptauName, zkeyName, logger);
+    // Discard csHash
+    await newZKey(r1csName, ptauName, zkeyName, logger);
+
+    return 0;
 }
 
 // zkey export bellman [circuit_0000.zkey] [circuit.mpcparams]
@@ -13121,8 +13146,9 @@ async function zkeyExportBellman(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return phase2exportMPCParams(zkeyName, mpcparamsName, logger);
+    await phase2exportMPCParams(zkeyName, mpcparamsName, logger);
 
+    return 0;
 }
 
 
@@ -13225,7 +13251,10 @@ async function zkeyContribute(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return phase2contribute(zkeyOldName, zkeyNewName, options.name, options.entropy, logger);
+    // Discard contribuionHash
+    await phase2contribute(zkeyOldName, zkeyNewName, options.name, options.entropy, logger);
+
+    return 0;
 }
 
 // zkey beacon <circuit_old.zkey> <circuit_new.zkey> <beaconHash(Hex)> <numIterationsExp>
@@ -13242,7 +13271,10 @@ async function zkeyBeacon(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return await beacon(zkeyOldName, zkeyNewName, options.name, beaconHashStr, numIterationsExp, logger);
+    // Discard contribuionHash
+    await beacon(zkeyOldName, zkeyNewName, options.name, beaconHashStr, numIterationsExp, logger);
+
+    return 0;
 }
 
 
@@ -13263,7 +13295,10 @@ async function zkeyBellmanContribute(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
-    return bellmanContribute(curve, challengeName, responseName, options.entropy, logger);
+    // Discard contributionHash
+    await bellmanContribute(curve, challengeName, responseName, options.entropy, logger);
+
+    return 0;
 }
 
 
@@ -13293,6 +13328,7 @@ async function plonkSetup(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
+    // TODO: Make plonk.setup reject instead of returning -1 or null
     return plonkSetup$1(r1csName, ptauName, zkeyName, logger);
 }
 
@@ -13367,6 +13403,7 @@ async function fflonkSetup(params, options) {
 
     if (options.verbose) Logger__default["default"].setLogLevel("DEBUG");
 
+    // TODO: Make fflonk.setup return valuable information or nothing at all
     return await fflonkSetup$1(r1csFilename, ptauFilename, zkeyFilename, logger);
 }
 

--- a/cli.js
+++ b/cli.js
@@ -712,7 +712,10 @@ async function powersOfTauNew(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return await powersOfTau.newAccumulator(curve, power, ptauName, logger);
+    // Discard firstChallengeHash
+    await powersOfTau.newAccumulator(curve, power, ptauName, logger);
+
+    return 0;
 }
 
 async function powersOfTauExportChallenge(params, options) {
@@ -729,7 +732,10 @@ async function powersOfTauExportChallenge(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return await powersOfTau.exportChallenge(ptauName, challengeName, logger);
+    // Discard curChallengeHash
+    await powersOfTau.exportChallenge(ptauName, challengeName, logger);
+
+    return 0;
 }
 
 // powersoftau challenge contribute <curve> <challenge> [response]
@@ -749,7 +755,9 @@ async function powersOfTauChallengeContribute(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return await powersOfTau.challengeContribute(curve, challengeName, responseName, options.entropy, logger);
+    await powersOfTau.challengeContribute(curve, challengeName, responseName, options.entropy, logger);
+
+    return 0;
 }
 
 
@@ -771,6 +779,7 @@ async function powersOfTauImport(params, options) {
 
     const res = await powersOfTau.importResponse(oldPtauName, response, newPtauName, options.name, importPoints, logger);
 
+    // TODO: This seems wrong
     if (res) return res;
     if (!doCheck) return;
 
@@ -805,7 +814,10 @@ async function powersOfTauBeacon(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return await powersOfTau.beacon(oldPtauName, newPtauName, options.name, beaconHashStr, numIterationsExp, logger);
+    // Discard hashResponse
+    await powersOfTau.beacon(oldPtauName, newPtauName, options.name, beaconHashStr, numIterationsExp, logger);
+
+    return 0;
 }
 
 async function powersOfTauContribute(params, options) {
@@ -817,7 +829,10 @@ async function powersOfTauContribute(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return await powersOfTau.contribute(oldPtauName, newPtauName, options.name, options.entropy, logger);
+    // Discard hashResponse
+    await powersOfTau.contribute(oldPtauName, newPtauName, options.name, options.entropy, logger);
+
+    return 0;
 }
 
 async function powersOfTauPreparePhase2(params, options) {
@@ -829,7 +844,9 @@ async function powersOfTauPreparePhase2(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return await powersOfTau.preparePhase2(oldPtauName, newPtauName, logger);
+    await powersOfTau.preparePhase2(oldPtauName, newPtauName, logger);
+
+    return 0;
 }
 
 async function powersOfTauConvert(params, options) {
@@ -841,7 +858,9 @@ async function powersOfTauConvert(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return await powersOfTau.convert(oldPtauName, newPtauName, logger);
+    await powersOfTau.convert(oldPtauName, newPtauName, logger);
+
+    return 0;
 }
 
 
@@ -857,7 +876,10 @@ async function powersOfTauTruncate(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return await powersOfTau.truncate(ptauName, template, logger);
+    // Discard `true`
+    await powersOfTau.truncate(ptauName, template, logger);
+
+    return 0;
 }
 
 // powersoftau export json <powersoftau_0000.ptau> <powersoftau_0000.json>",
@@ -902,7 +924,10 @@ async function zkeyNew(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return zkey.newZKey(r1csName, ptauName, zkeyName, logger);
+    // Discard csHash
+    await zkey.newZKey(r1csName, ptauName, zkeyName, logger);
+
+    return 0;
 }
 
 // zkey export bellman [circuit_0000.zkey] [circuit.mpcparams]
@@ -920,8 +945,9 @@ async function zkeyExportBellman(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return zkey.exportBellman(zkeyName, mpcparamsName, logger);
+    await zkey.exportBellman(zkeyName, mpcparamsName, logger);
 
+    return 0;
 }
 
 
@@ -1024,7 +1050,10 @@ async function zkeyContribute(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return zkey.contribute(zkeyOldName, zkeyNewName, options.name, options.entropy, logger);
+    // Discard contribuionHash
+    await zkey.contribute(zkeyOldName, zkeyNewName, options.name, options.entropy, logger);
+
+    return 0;
 }
 
 // zkey beacon <circuit_old.zkey> <circuit_new.zkey> <beaconHash(Hex)> <numIterationsExp>
@@ -1041,7 +1070,10 @@ async function zkeyBeacon(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return await zkey.beacon(zkeyOldName, zkeyNewName, options.name, beaconHashStr, numIterationsExp, logger);
+    // Discard contribuionHash
+    await zkey.beacon(zkeyOldName, zkeyNewName, options.name, beaconHashStr, numIterationsExp, logger);
+
+    return 0;
 }
 
 
@@ -1062,7 +1094,10 @@ async function zkeyBellmanContribute(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
-    return zkey.bellmanContribute(curve, challengeName, responseName, options.entropy, logger);
+    // Discard contributionHash
+    await zkey.bellmanContribute(curve, challengeName, responseName, options.entropy, logger);
+
+    return 0;
 }
 
 
@@ -1092,6 +1127,7 @@ async function plonkSetup(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
+    // TODO: Make plonk.setup reject instead of returning -1 or null
     return plonk.setup(r1csName, ptauName, zkeyName, logger);
 }
 
@@ -1166,6 +1202,7 @@ async function fflonkSetup(params, options) {
 
     if (options.verbose) Logger.setLogLevel("DEBUG");
 
+    // TODO: Make fflonk.setup return valuable information or nothing at all
     return await fflonk.setup(r1csFilename, ptauFilename, zkeyFilename, logger);
 }
 


### PR DESCRIPTION
Fixes #366

This fixes usage of various commands in the CLI. Generally, we want to avoid returning function calls because they return values that might be used in application code; however the CLI expect integers to be returned so it can call `process.exit(code)`.

@chentihe please try this code and see if it works.