### PR TITLE
Add npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+# ignore everything first
+*
+
+# only include those that are needed
+!COPYING
+!README.md
+!package.json
+!templates
+
+!build
+!main.js
+!cli.js


### PR DESCRIPTION
SnarkJS [NPM package](https://www.npmjs.com/package/snarkjs) is 50MBs. This is mostly because almost the entire code is uploaded to NPM, which includes tests that have WASM files and keys in it that take a lot of space.

Adding a simple NPM ignore should reduce the NPM package size to much much smaller levels. I've added one, hoping that I got all build files correct.

I had to make this PR especially because I would like to use some packages in serverless but there is a size limit thats becoming problematic due to already large `node_modules`.