### PR TITLE
fix r1cs one print

### DIFF
--- a/src/r1cs_print.js
+++ b/src/r1cs_print.js
@@ -27,7 +27,7 @@ export default function r1csPrint(r1cs, syms, logger) {
             const keys = Object.keys(lc);
             keys.forEach( (k) => {
                 let name = syms.varIdx2Name[k];
-                if (name == "one") name = "1";
+                if (name == "one") name = "*1";
 
                 let vs = r1cs.curve.Fr.toString(lc[k]);
                 if (vs == "1") vs = "";  // Do not show ones


### PR DESCRIPTION
snarkjs r1cs print  build/demo.r1cs build/demo.sym

before :
[INFO]  snarkJS: [  ] * [  ] - [ **218882428718392752222464057452572750885483644004160343436982041865758084956061** +main.a +21888242871839275222246405745257275088548364400416034343698204186575808495616main.a_11 ] = 0

after :
[INFO]  snarkJS: [  ] * [  ] - [ **21888242871839275222246405745257275088548364400416034343698204186575808495606***1 +main.a +21888242871839275222246405745257275088548364400416034343698204186575808495616main.a_11 ] = 0

After making this change, the readability has improved a lot for me.