### PR TITLE
Optimize: change contract function visibility to "external"

### DIFF
--- a/templates/verifier_fflonk.sol.ejs
+++ b/templates/verifier_fflonk.sol.ejs
@@ -166,7 +166,7 @@ contract FflonkVerifier {
 <%      inversionArray.push(`pEval_l${i}`); -%>
 <% } -%>
 
-    function verifyProof(bytes32[24] calldata proof, uint256[<%- Math.max(nPublic, 1) %>] calldata pubSignals) public view returns (bool) {
+    function verifyProof(bytes32[24] calldata proof, uint256[<%- Math.max(nPublic, 1) %>] calldata pubSignals) external view returns (bool) {
         assembly {
             // Computes the inverse of an array of values
             // See https://vitalik.ca/general/2018/07/21/starks_part_3.html in section where explain fields operations

--- a/templates/verifier_groth16.sol.ejs
+++ b/templates/verifier_groth16.sol.ejs
@@ -53,7 +53,7 @@ contract Groth16Verifier {
 
     uint16 constant pLastMem = 896;
 
-    function verifyProof(uint[2] calldata _pA, uint[2][2] calldata _pB, uint[2] calldata _pC, uint[<%=IC.length-1%>] calldata _pubSignals) public view returns (bool) {
+    function verifyProof(uint[2] calldata _pA, uint[2][2] calldata _pB, uint[2] calldata _pC, uint[<%=IC.length-1%>] calldata _pubSignals) external view returns (bool) {
         assembly {
             function checkField(v) {
                 if iszero(lt(v, q)) {

--- a/templates/verifier_plonk.sol.ejs
+++ b/templates/verifier_plonk.sol.ejs
@@ -120,7 +120,7 @@ contract PlonkVerifier {
     
     uint16 constant lastMem = <%=pLastMem%>;
 
-    function verifyProof(uint256[24] calldata _proof, uint256[<%=nPublic%>] calldata _pubSignals) public view returns (bool) {
+    function verifyProof(uint256[24] calldata _proof, uint256[<%=nPublic%>] calldata _pubSignals) external view returns (bool) {
         assembly {
             /////////
             // Computes the inverse using the extended euclidean algorithm

--- a/test/fflonk/verifier.sol
+++ b/test/fflonk/verifier.sol
@@ -159,7 +159,7 @@ contract FflonkVerifier {
     uint16 constant lastMem = 1920;
      
 
-    function verifyProof(bytes32[24] calldata proof, uint256[1] calldata pubSignals) public view returns (bool) {
+    function verifyProof(bytes32[24] calldata proof, uint256[1] calldata pubSignals) external view returns (bool) {
         assembly {
             // Computes the inverse of an array of values
             // See https://vitalik.ca/general/2018/07/21/starks_part_3.html in section where explain fields operations

--- a/test/plonk_circuit/verifier.sol
+++ b/test/plonk_circuit/verifier.sol
@@ -106,7 +106,7 @@ contract PlonkVerifier {
     
     uint16 constant lastMem = 864;
 
-    function verifyProof(bytes memory proof, uint[] memory pubSignals) public view returns (bool) {
+    function verifyProof(bytes memory proof, uint[] memory pubSignals) external view returns (bool) {
         assembly {
             /////////
             // Computes the inverse using the extended euclidean algorithm


### PR DESCRIPTION
In `verifyProof` function, it uses yul functions like `calldataload`, `return`, which will be interpreted to `CALLDATALOAD` and `RETURN` opcodes, and these opcodes only make sense when the calling context is an external call.

Currently, the visibility of the generated contract functions are `public` and may be used unexpected as an internal call, like:

```
contract MisusingVerifier is FflonkVerifier {
    function verify(...) {
        verifyProof(...)     // this will be an internal call and unexpected results may occur
    }
}

```


This PR changes `public` to `external` to avoid unexpected usage of the verifier contracts.