### PR TITLE
Bump dependency version

### DIFF
--- a/browser_tests/package-lock.json
+++ b/browser_tests/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "snarkjs-browser-tests",
       "devDependencies": {
-        "ffjavascript": "^0.2.62",
+        "ffjavascript": "^0.3.0",
         "puppeteer": "20.2.0",
         "st": "3.0.0"
       }
@@ -414,14 +414,14 @@
       }
     },
     "node_modules/ffjavascript": {
-      "version": "0.2.62",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.62.tgz",
-      "integrity": "sha512-uJ7MTrdzhX/3f+hxn0XhdXbJCqYZJSBB6y2/ui4t21vKYVjyTMlU80pPXu40ir6qpqbrdzUeKdlOdJ0aFG9UNA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.3.0.tgz",
+      "integrity": "sha512-l7sR5kmU3gRwDy8g0Z2tYBXy5ttmafRPFOqY7S6af5cq51JqJWt5eQ/lSR/rs2wQNbDYaYlQr5O+OSUf/oMLoQ==",
       "dev": true,
       "dependencies": {
         "wasmbuilder": "0.0.16",
         "wasmcurves": "0.2.2",
-        "web-worker": "^1.2.0"
+        "web-worker": "1.2.0"
       }
     },
     "node_modules/fs-constants": {

--- a/browser_tests/package.json
+++ b/browser_tests/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "puppeteer": "20.2.0",
-    "ffjavascript": "^0.2.62",
+    "ffjavascript": "^0.3.0",
     "st": "3.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.7.3",
       "license": "GPL-3.0",
       "dependencies": {
-        "@iden3/binfileutils": "0.0.11",
+        "@iden3/binfileutils": "0.0.12",
         "bfj": "^7.0.2",
         "blake2b-wasm": "^2.4.0",
-        "circom_runtime": "0.1.24",
+        "circom_runtime": "0.1.25",
         "ejs": "^3.1.6",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.63",
+        "ffjavascript": "0.3.0",
         "js-sha3": "^0.8.0",
         "logplease": "^1.2.15",
-        "r1csfile": "0.0.47"
+        "r1csfile": "0.0.48"
       },
       "bin": {
         "snarkjs": "build/cli.cjs"
@@ -318,12 +318,12 @@
       "integrity": "sha512-Xzdyxqm1bOFF6pdIsiHLLl3HkSLjbhqJHVyqaTxXt3RqXBEnmsUmEW47H7VOi/ak7TdkRpNkxjyK5Zbkm+y52g=="
     },
     "node_modules/@iden3/binfileutils": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@iden3/binfileutils/-/binfileutils-0.0.11.tgz",
-      "integrity": "sha512-LylnJoZ0CTdgErnKY8OxohvW4K+p6UHD3sxt+3P9AmMyBQjYR4IpoqoYZZ+9aMj89cmCQ21UvdhndAx04er3NA==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@iden3/binfileutils/-/binfileutils-0.0.12.tgz",
+      "integrity": "sha512-naAmzuDufRIcoNfQ1d99d7hGHufLA3wZSibtr4dMe6ZeiOPV1KwOZWTJ1YVz4HbaWlpDuzVU72dS4ATQS4PXBQ==",
       "dependencies": {
         "fastfile": "0.0.20",
-        "ffjavascript": "^0.2.48"
+        "ffjavascript": "^0.3.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -817,24 +817,14 @@
       }
     },
     "node_modules/circom_runtime": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.24.tgz",
-      "integrity": "sha512-H7/7I2J/cBmRnZm9docOCGhfxzS61BEm4TMCWcrZGsWNBQhePNfQq88Oj2XpUfzmBTCd8pRvRb3Mvazt3TMrJw==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/circom_runtime/-/circom_runtime-0.1.25.tgz",
+      "integrity": "sha512-xBGsBFF5Uv6AKvbpgExYqpHfmfawH2HKe+LyjfKSRevqEV8u63i9KGHVIILsbJNW+0c5bm/66f0PUYQ7qZSkJA==",
       "dependencies": {
-        "ffjavascript": "0.2.60"
+        "ffjavascript": "0.3.0"
       },
       "bin": {
         "calcwit": "calcwit.js"
-      }
-    },
-    "node_modules/circom_runtime/node_modules/ffjavascript": {
-      "version": "0.2.60",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.60.tgz",
-      "integrity": "sha512-T/9bnEL5xAZRDbQoEMf+pM9nrhK+C3JyZNmqiWub26EQorW7Jt+jR54gpqDhceA4Nj0YctPQwYnl8xa52/A26A==",
-      "dependencies": {
-        "wasmbuilder": "0.0.16",
-        "wasmcurves": "0.2.2",
-        "web-worker": "^1.2.0"
       }
     },
     "node_modules/cliui": {
@@ -1297,9 +1287,9 @@
       }
     },
     "node_modules/ffjavascript": {
-      "version": "0.2.63",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.63.tgz",
-      "integrity": "sha512-dBgdsfGks58b66JnUZeZpGxdMIDQ4QsD3VYlRJyFVrKQHb2kJy4R2gufx5oetrTxXPT+aEjg0dOvOLg1N0on4A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.3.0.tgz",
+      "integrity": "sha512-l7sR5kmU3gRwDy8g0Z2tYBXy5ttmafRPFOqY7S6af5cq51JqJWt5eQ/lSR/rs2wQNbDYaYlQr5O+OSUf/oMLoQ==",
       "dependencies": {
         "wasmbuilder": "0.0.16",
         "wasmcurves": "0.2.2",
@@ -2229,24 +2219,14 @@
       ]
     },
     "node_modules/r1csfile": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.47.tgz",
-      "integrity": "sha512-oI4mAwuh1WwuFg95eJDNDDL8hCaZkwnPuNZrQdLBWvDoRU7EG+L/MOHL7SwPW2Y+ZuYcTLpj3rBkgllBQZN/JA==",
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/r1csfile/-/r1csfile-0.0.48.tgz",
+      "integrity": "sha512-kHRkKUJNaor31l05f2+RFzvcH5XSa7OfEfd/l4hzjte6NL6fjRkSMfZ4BjySW9wmfdwPOtq3mXurzPvPGEf5Tw==",
       "dependencies": {
         "@iden3/bigarray": "0.0.2",
-        "@iden3/binfileutils": "0.0.11",
+        "@iden3/binfileutils": "0.0.12",
         "fastfile": "0.0.20",
-        "ffjavascript": "0.2.60"
-      }
-    },
-    "node_modules/r1csfile/node_modules/ffjavascript": {
-      "version": "0.2.60",
-      "resolved": "https://registry.npmjs.org/ffjavascript/-/ffjavascript-0.2.60.tgz",
-      "integrity": "sha512-T/9bnEL5xAZRDbQoEMf+pM9nrhK+C3JyZNmqiWub26EQorW7Jt+jR54gpqDhceA4Nj0YctPQwYnl8xa52/A26A==",
-      "dependencies": {
-        "wasmbuilder": "0.0.16",
-        "wasmcurves": "0.2.2",
-        "web-worker": "^1.2.0"
+        "ffjavascript": "0.3.0"
       }
     },
     "node_modules/randombytes": {

--- a/package.json
+++ b/package.json
@@ -56,16 +56,16 @@
     "url": "https://github.com/iden3/snarkjs.git"
   },
   "dependencies": {
-    "@iden3/binfileutils": "0.0.11",
+    "@iden3/binfileutils": "0.0.12",
     "bfj": "^7.0.2",
     "blake2b-wasm": "^2.4.0",
-    "circom_runtime": "0.1.24",
+    "circom_runtime": "0.1.25",
     "ejs": "^3.1.6",
     "fastfile": "0.0.20",
-    "ffjavascript": "0.2.63",
+    "ffjavascript": "0.3.0",
     "js-sha3": "^0.8.0",
     "logplease": "^1.2.15",
-    "r1csfile": "0.0.47"
+    "r1csfile": "0.0.48"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",


### PR DESCRIPTION
Fixes #476, #97

Following dependencies were updated:
* https://github.com/iden3/ffjavascript/releases/tag/v0.3.0
* https://github.com/iden3/circom_runtime/releases/tag/v0.1.25
* https://github.com/iden3/binfileutils/releases/tag/v0.0.12
* https://github.com/iden3/r1csfile/releases/tag/v0.0.48

Changes in packages can be seen on respective package release pages (and all changes at once can be viewed with Full Changelog link at the bottom of the description).