### PR TITLE
Pass options object to WitnessCalculatorBuilder

### DIFF
--- a/src/wtns_calculate.js
+++ b/src/wtns_calculate.js
@@ -31,7 +31,7 @@ export default async function wtnsCalculate(_input, wasmFileName, wtnsFileName, 
     const wasm = await fdWasm.read(fdWasm.totalSize);
     await fdWasm.close();
 
-    const wc = await WitnessCalculatorBuilder(wasm);
+    const wc = await WitnessCalculatorBuilder(wasm, options);
     if (wc.circom_version() == 1) {
         const w = await wc.calculateBinWitness(input);
 


### PR DESCRIPTION
### Changes

The `WitnessCalculatorBuilder` constructor allows for an `options` object which is not being passed through even though it is in scope. This PR fixes this problem

### Context
See [this PR](https://github.com/iden3/circom_runtime/pull/107) in circom_runtime