### PR TITLE
Export curves

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,3 +5,4 @@ export * as wtns from "./src/wtns.js";
 export * as zKey from "./src/zkey.js";
 export * as plonk from "./src/plonk.js";
 export * as fflonk from "./src/fflonk.js";
+export * as curves from "./src/curves.js";


### PR DESCRIPTION
Export curves to allow terminating wasm threads (curve.terminate) from outside code.
Fixes #494 with the following changes in the[ bug reproduction code](https://github.com/dovgopoly/snarkjs-issue/blob/master/main.js):
```js
async function main() {
    const r1cs = "rsc/Multiplier.r1cs";
    const ptau = "rsc/powersOfTau28_hez_final_08.ptau";
    const zkey = "rsc/Multiplier.zkey"

    // initializes the curve object controlling wasm threads
    let curve = await snarkjs.curves.getCurveFromName("bn128");

    await snarkjs.r1cs.info(r1cs, console);
    await snarkjs.zKey.newZKey(r1cs, ptau, zkey, console);

    // terminates threads
    curve.terminate();
}
```