### PR TITLE
fix: dead links

### DIFF
--- a/src/fflonk_prove.js
+++ b/src/fflonk_prove.js
@@ -120,7 +120,7 @@ export default async function fflonkProve(zkeyFileName, witnessFileName, logger,
     // The Extended Euclidean Algorithm is expensive in terms of computation.
     // For the special case where we need to do many modular inverses, there's a simple mathematical trick
     // that allows us to compute many inverses, called Montgomery batch inversion.
-    // More info: https://vitalik.ca/general/2018/07/21/starks_part_3.html
+    // More info: https://vitalik.eth.limo/general/2018/07/21/starks_part_3.html
     // Montgomery batch inversion reduces the n inverse computations to a single one
     // To save this (single) inverse computation on-chain, will compute it in proving time and send it to the verifier.
     // The verifier will have to check:

--- a/templates/verifier_fflonk.sol.ejs
+++ b/templates/verifier_fflonk.sol.ejs
@@ -169,7 +169,7 @@ contract FflonkVerifier {
     function verifyProof(bytes32[24] calldata proof, uint256[<%- Math.max(nPublic, 1) %>] calldata pubSignals) public view returns (bool) {
         assembly {
             // Computes the inverse of an array of values
-            // See https://vitalik.ca/general/2018/07/21/starks_part_3.html in section where explain fields operations
+            // See https://vitalik.eth.limo/general/2018/07/21/starks_part_3.html in section where explain fields operations
             // To save the inverse to be computed on chain the prover sends the inverse as an evaluation in commits.eval_inv
             function inverseArray(pMem) {
 
@@ -865,7 +865,7 @@ contract FflonkVerifier {
 
             // To divide prime fields the Extended Euclidean Algorithm for computing modular inverses is needed.
             // The Montgomery batch inversion algorithm allow us to compute n inverses reducing to a single one inversion.
-            // More info: https://vitalik.ca/general/2018/07/21/starks_part_3.html
+            // More info: https://vitalik.eth.limo/general/2018/07/21/starks_part_3.html
             // To avoid this single inverse computation on-chain, it has been computed in proving time and send it to the verifier.
             // Therefore, the verifier:
             //      1) Prepare all the denominators to inverse

--- a/templates/verifier_plonk.sol.ejs
+++ b/templates/verifier_plonk.sol.ejs
@@ -150,7 +150,7 @@ contract PlonkVerifier {
             
             ///////
             // Computes the inverse of an array of values
-            // See https://vitalik.ca/general/2018/07/21/starks_part_3.html in section where explain fields operations
+            // See https://vitalik.eth.limo/general/2018/07/21/starks_part_3.html in section where explain fields operations
             //////
             function inverseArray(pVals, n) {
     


### PR DESCRIPTION
Hey! I noticed that a few files had links to Vitalik’s article pointing to vitalik.ca, but that domain doesn’t work anymore. I updated the links to the new domain — vitalik.eth.limo.