### PR TITLE
fix: update GitHub Actions badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-![tests](https://github.com/iden3/snarkjs/workflows/tests/badge.svg)![Check%20snarkjs%20tutorial](https://github.com/iden3/snarkjs/workflows/Check%20snarkjs%20tutorial/badge.svg)
+![tests](https://github.com/iden3/snarkjs/actions/workflows/ci.yml/badge.svg)![Check%20snarkjs%20tutorial](https://github.com/iden3/snarkjs/actions/workflows/tutorial.yml/badge.svg)
 
 # snarkjs
 


### PR DESCRIPTION
Fix broken badge URLs in README.md by updating them to use the modern GitHub Actions workflow format. Changed from the deprecated format (github.com/iden3/snarkjs/workflows/tests/badge.svg) to the current format (github.com/iden3/snarkjs/actions/workflows/ci.yml/badge.svg) for both the tests and tutorial badges.