### PR TITLE
Abort extracting vk when there are no phase 2 contributions

### DIFF
--- a/src/groth16_verify.js
+++ b/src/groth16_verify.js
@@ -69,6 +69,11 @@ export default async function groth16Verify(_vk_verifier, _publicSignals, _proof
     const vk_alpha_1 = curve.G1.fromObject(vk_verifier.vk_alpha_1);
     const vk_beta_2 = curve.G2.fromObject(vk_verifier.vk_beta_2);
 
+    if (curve.G2.eq(vk_gamma_2, vk_delta_2)) {
+        if (logger) logger.error("SOUNDNESS ERROR: vk_gamma_2 and vk_delta_2 are equal. This verification key is insecure, the zkey likely has no phase 2 contribution. Proofs can be forged. Aborting verification.");
+        return false;
+    }
+
     const res = await curve.pairingEq(
         curve.G1.neg(pi_a) , pi_b,
         cpub , vk_gamma_2,

--- a/src/zkey_export_solidityverifier.js
+++ b/src/zkey_export_solidityverifier.js
@@ -9,6 +9,14 @@ export default async function exportSolidityVerifier(zKeyName, templates, logger
 
     const verificationKey = await exportVerificationKey(zKeyName, logger);
 
+    if (verificationKey.protocol === "groth16") {
+        const vkGamma2 = JSON.stringify(verificationKey.vk_gamma_2);
+        const vkDelta2 = JSON.stringify(verificationKey.vk_delta_2);
+        if (vkGamma2 === vkDelta2) {
+            throw new Error("SOUNDNESS ERROR: vk_gamma_2 and vk_delta_2 are equal. This zkey is insecure, it likely has no phase 2 contribution. Proofs can be forged. Run 'snarkjs zkey contribute' before exporting.");
+        }
+    }
+
     if ("fflonk" === verificationKey.protocol) {
         return fflonkExportSolidityVerifierCmd(verificationKey, templates, logger);
     }

--- a/src/zkey_export_solidityverifier.js
+++ b/src/zkey_export_solidityverifier.js
@@ -9,14 +9,6 @@ export default async function exportSolidityVerifier(zKeyName, templates, logger
 
     const verificationKey = await exportVerificationKey(zKeyName, logger);
 
-    if (verificationKey.protocol === "groth16") {
-        const vkGamma2 = JSON.stringify(verificationKey.vk_gamma_2);
-        const vkDelta2 = JSON.stringify(verificationKey.vk_delta_2);
-        if (vkGamma2 === vkDelta2) {
-            throw new Error("SOUNDNESS ERROR: vk_gamma_2 and vk_delta_2 are equal. This zkey is insecure, it likely has no phase 2 contribution. Proofs can be forged. Run 'snarkjs zkey contribute' before exporting.");
-        }
-    }
-
     if ("fflonk" === verificationKey.protocol) {
         return fflonkExportSolidityVerifierCmd(verificationKey, templates, logger);
     }

--- a/src/zkey_export_verificationkey.js
+++ b/src/zkey_export_verificationkey.js
@@ -56,6 +56,10 @@ async function groth16Vk(zkey, fd, sections) {
     const curve = await getCurve(zkey.q);
     const sG1 = curve.G1.F.n8 * 2;
 
+    if (curve.G2.eq(zkey.vk_gamma_2, zkey.vk_delta_2)) {
+        throw new Error("SOUNDNESS ERROR: vk_gamma_2 and vk_delta_2 are equal. This zkey is insecure, it likely has no phase 2 contribution. Proofs can be forged. Run 'snarkjs zkey contribute' before exporting.");
+    }
+
     const alphaBeta = await curve.pairing(zkey.vk_alpha_1, zkey.vk_beta_2);
 
     let vKey = {


### PR DESCRIPTION
Following recent exploits in which users didn't contribute in phase 2 before extracting their verification key, I suggest adding a check and printing an error message in such cases.

Context:

https://x.com/PashovAuditGrp/status/2025598503255167195?s=20
https://x.com/blockaid_/status/2026937160079970737
https://blog.zksecurity.xyz/posts/groth16-setup-exploit/